### PR TITLE
add env var LDFLAGS to FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #modied from htslib makefile
-FLAGS=-O3 -D__WITH_POOL__
+FLAGS=-O3 -D__WITH_POOL__ ${LDFLAGS}
 
 CFLAGS += $(FLAGS)
 CXXFLAGS += $(FLAGS)

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CXX=g++
 
-FLAGS=-O3
+FLAGS=-O3 ${LDFLAGS}
 
 ifdef HTSSRC
 $(info HTSSRC defined)
@@ -113,7 +113,7 @@ analysisFunction:
 	make -C ../ analysisFunction.o HTSSRC=$(realpath $(HTSSRC))
 
 realSFS: realSFS.cpp safreader.o keep.hpp safstat.o realSFS_args.o header.o fstreader.o safcat.o multisafreader.hpp prep_sites analysisFunction realSFS_optim.o realSFS_shared.o realSFS_dadi.o
-	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_dadi.o realSFS_shared.o ../prep_sites.o ../analysisFunction.o -I $(HTS_INCDIR) $(HTS_LIBDIR) -lz -lm -lbz2 -llzma -lpthread
+	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_dadi.o realSFS_shared.o ../prep_sites.o ../analysisFunction.o -I $(HTS_INCDIR) $(HTS_LIBDIR) -lz -lm -lbz2 -llzma -lpthread -lcurl
 else
 safreader.o: safreader.cpp safreader.h header.h
 	$(CXX) $(FLAGS) -c safreader.cpp 


### PR DESCRIPTION
This makes it possible to do something like

export LDFLAGS="-L/path/to/your/local/libs"

before compilation on a system where the libraries have been installed
locally. Without this, compilation fails for anybody who stores
libraries in their home directory, e.g. for users without root access.
LDFLAGS is the standard environment variable for this purpose.

Also, add a missing -lcurl to compilation of realSFS. I found I needed
this.