### PR TITLE
Added -doAsso methods 4, 5 and 6

### DIFF
--- a/abcAsso.cpp
+++ b/abcAsso.cpp
@@ -991,8 +991,11 @@ int abcAsso::getFitWLSBin(double* start, double* y, double** covMatrix, double* 
    std::vector<double> z(nInd3);
    std::vector<double> w(nInd3);
    std::vector<double> Xt_y(nEnv);
-   std::vector<double> invXtX_Xt_y(nEnv);
-   double XtX[nEnv*nEnv] = {0};
+   std::vector<double> invXtX_Xt_y(nEnv);   
+   double XtX[nEnv*nEnv];
+
+   for(int i=0;i<nEnv*nEnv;i++)
+     XtX[i]=0;
    
    //   double mu0[nInd3];
    //double muetaval[nInd3];

--- a/abcAsso.h
+++ b/abcAsso.h
@@ -3,10 +3,12 @@
 typedef struct{
 
   double **stat;
+  double **statOther; //for likelihood of other model added by emil 14-11-2018
   int **keepInd;
   int *highHe;
   int *highWt;
   int *highHo;
+  double *betas; //for coefficients added by emil 07-11-2018
 }assoStruct;
 
 
@@ -30,6 +32,10 @@ public:
   int minCount;
   int adjust;  //not for users
   int model;
+  int mIter; //not for users
+  double threshold; //not for users
+  double hybridThres; //not for users
+  
   void run(funkyPars  *pars);
   void print(funkyPars *pars);  
   void clean(funkyPars *pars);  
@@ -45,6 +51,16 @@ public:
   angsd::Matrix<double> ymat;
   angsd::Matrix<double> covmat;
   void scoreAsso(funkyPars  *pars,assoStruct *assoc);
+  double dosageAssoc(funkyPars *p,angsd::Matrix<double> *design,angsd::Matrix<double> *designNull,double *postOrg,double *yOrg,int keepInd,int *keepList,double freq,int s,assoStruct *assoc,int model, int isBinary, double* start, int fullModel);
+  void dosageAsso(funkyPars  *pars,assoStruct *assoc);
+  int getFitWLS(double* start, double* y, double** covMatrix, double* weights, int nInd3, int nEnv, int df);
+  int getFitWLSBin(double* start, double* y, double** covMatrix, double* weights, int nInd3, int nEnv, int df);
+  double logLike(double *start,double* y,angsd::Matrix<double> *design,double *post,int isBinary, int fullModel);
+  double logupdateEM(double* start,angsd::Matrix<double> *design,angsd::Matrix<double> *postAll,double* y,int keepInd,double* post,int isBinary, int fullModel);
+  double sd(double* phe, int size );
+  double doEMasso(funkyPars *p,angsd::Matrix<double> *design,angsd::Matrix<double> *designNull,angsd::Matrix<double> *postAll,double *postOrg,double *yOrg,int keepInd,int *keepList,double freq,int s,assoStruct *assoc,int model, int isBinary, double* start, int fullModel);  
+  void emAsso(funkyPars  *pars,assoStruct *assoc);
+  void hybridAsso(funkyPars  *pars,assoStruct *assoc);
   void frequencyAsso(funkyPars  *pars,assoStruct *assoc);
   double doAssociation(funkyPars *pars,double *post,double *y,int keepInd,int *keepList,double freq,int s,assoStruct *assoc);
   int getFit(double *res,double *Y,double *covMatrix,int nInd,int nEnv);

--- a/abcAsso.h
+++ b/abcAsso.h
@@ -63,8 +63,8 @@ public:
   void hybridAsso(funkyPars  *pars,assoStruct *assoc);
   void frequencyAsso(funkyPars  *pars,assoStruct *assoc);
   double doAssociation(funkyPars *pars,double *post,double *y,int keepInd,int *keepList,double freq,int s,assoStruct *assoc);
-  int getFit(double *res,double *Y,double *covMatrix,int nInd,int nEnv);
-  int getFitBin(double *res,double *Y,double *covMatrix,int nInd,int nEnv);
+  int getFit(double *res,double *Y,double *covMatrix,int nInd,int nEnv, double *start);
+  int getFitBin(double *res,double *Y,double *covMatrix,int nInd,int nEnv, double *start);
   double normScoreEnv(double *post,int numInds, double *y, double *ytilde,double *cov,int nEnv,double freq,assoStruct *assoc,int s);
   double binomScoreEnv(double *post,int numInds, double *y, double *ytilde,double *cov,int nEnv,double freq,assoStruct *assoc,int s);
   void printDoAsso(funkyPars *pars);

--- a/abcAsso.h
+++ b/abcAsso.h
@@ -32,9 +32,12 @@ public:
   int minCount;
   int adjust;  //not for users
   int model;
-  int mIter; //not for users
-  double threshold; //not for users
-  double hybridThres; //not for users
+  int emIter;
+  int assoIter; 
+  double emThres;
+  double assoThres; 
+  double hybridThres; 
+  
   
   void run(funkyPars  *pars);
   void print(funkyPars *pars);  

--- a/abcFreq.cpp
+++ b/abcFreq.cpp
@@ -17,16 +17,11 @@
 #include "abcFreq.h"
 #include "abcSaf.h"
 #include "abcFilter.h"
-
+#include "analysisFunction.h"
 
 int abcFreq::emIter = EM_NITER;
 double abcFreq::EM_start = EM_START;
 double *abcFreq::indF = NULL;
-
-double abcFreq::to_pval(Chisqdist *chisq,double f){
-  return f<0?1:1-chisq->cdf(f);
-}
-
 
 //simple phat estimator from the 200danes article, one site function
 double phatFun(suint *counts,int nFiles,double eps,char major,char minor) {
@@ -405,9 +400,9 @@ void abcFreq::print(funkyPars *pars) {
       ksprintf(&bufstr,"%f\t",freq->phat[s]);
     if(doSNP){
       if(doMaf &1)
-	ksprintf(&bufstr,"%e\t",to_pval(chisq1,freq->lrt_EM[s]));
+	ksprintf(&bufstr,"%e\t",angsd::to_pval(chisq1,freq->lrt_EM[s]));
       if(doMaf &2)
-	ksprintf(&bufstr,"%e\t",to_pval(chisq1,freq->lrt_EM_unknown[s]));
+	ksprintf(&bufstr,"%e\t",angsd::to_pval(chisq1,freq->lrt_EM_unknown[s]));
     }
 
     kputw(pars->keepSites[s],&bufstr);kputc('\n',&bufstr);

--- a/abcFreq.h
+++ b/abcFreq.h
@@ -17,7 +17,6 @@ class abcFreq:public abc{
 private:
   int underflowprotect;
   kstring_t bufstr;
-  double to_pval(Chisqdist *str,double f);
   Chisqdist *chisq1;
   Chisqdist *chisq2;
   Chisqdist *chisq3;

--- a/analysisFunction.cpp
+++ b/analysisFunction.cpp
@@ -1208,9 +1208,9 @@ double angsd::bernoulli(int k, double p, int ifLog){
   }
   
   if(ifLog){
-    return( pow(p,k)*pow(1-p,1-k) );
-  } else{
     return( log(pow(p,k)*pow(1-p,1-k)) );
+  } else{
+    return( pow(p,k)*pow(1-p,1-k) );
   }
 }
 

--- a/analysisFunction.cpp
+++ b/analysisFunction.cpp
@@ -1174,14 +1174,11 @@ double angsd::dnorm(double x,double mean,double sd,int ifLog){
 
   double lower_bound=1e-20;//emil - not for users
 
-  if(ifLog){
-    fac = log(fac);
-    val = log(val);
-
+  if(ifLog){    
     if(val<lower_bound){
       return(log(lower_bound));
     } else{
-      return (fac+val);
+      return (log(fac)+log(val));
     }    
   } else{
     // if val is 0 because exp(-(x-mean)*(x-mean)) is due to underflow, returns low value

--- a/analysisFunction.cpp
+++ b/analysisFunction.cpp
@@ -1228,6 +1228,10 @@ double angsd::sd(double* phe, int size ){
   return ts/(1.0*(size-1.0));
 }
 
+double angsd::to_pval(Chisqdist *chisq,double f){
+  return f<0?1:1-chisq->cdf(f);
+}
+
 
 
 

--- a/analysisFunction.h
+++ b/analysisFunction.h
@@ -64,6 +64,9 @@ namespace angsd {
   void printMatrix(Matrix<double> mat,FILE *file);
   void logrescale(double *ary,int len);
   int svd_inverse(double mat[],int xLen, int yLen);
+  double dnorm(double x,double mean,double sd,int ifLog);
+  double bernoulli(int k, double p, int ifLog);
+  double sd(double* phe, int size );
   std::vector<char*> getFilenames(const char * name,int nInd);
   char *strpop(char **str,char split);
   int getRandomCount(suint *d, int i,  int depth = -1);

--- a/analysisFunction.h
+++ b/analysisFunction.h
@@ -67,6 +67,7 @@ namespace angsd {
   double dnorm(double x,double mean,double sd,int ifLog);
   double bernoulli(int k, double p, int ifLog);
   double sd(double* phe, int size );
+  double to_pval(Chisqdist *chisq,double f);
   std::vector<char*> getFilenames(const char * name,int nInd);
   char *strpop(char **str,char split);
   int getRandomCount(suint *d, int i,  int depth = -1);

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -105,7 +105,7 @@ multisafreader.hpp: Matrix.hpp realSFS_shared.o
 
 
 realSFS: realSFS.cpp safreader.o keep.hpp safstat.o realSFS_args.o header.o fstreader.o safcat.o multisafreader.hpp realSFS_optim.o realSFS_shared.o realSFS_dadi.o
-	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_shared.o ../prep_sites.o ../analysisFunction.o realSFS_dadi.o $(LIBS) -lz -lpthread
+	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_shared.o ../prep_sites.o ../analysisFunction.o ../chisquare.o realSFS_dadi.o $(LIBS) -lz -lpthread
 
 hmm_psmc.o: hmm_psmc.cpp hmm_psmc.h compute.c
 	$(CXX) $(FLAGS) -c hmm_psmc.cpp


### PR DESCRIPTION
Added 3 new methods to -doAsso:

4: is a latent genotype model, using the EM algorithm. Estimates effect sizes.
5: is a hybrid model, first running the score test (-doAsso 2) and then if the p-value is below a certain threshold (which can be specified) the latent genotype model.
6: is regular regression using dosages.