### PR TITLE
Fixed multithreading bug that is breaking the EM optimization

### DIFF
--- a/misc/realSFS_optim.cpp
+++ b/misc/realSFS_optim.cpp
@@ -324,7 +324,10 @@ void emStep_master(double *post,int nThreads){
   }
   
   for(int j=0;j<emp[0].dim;j++)
-    post[j] /= double(emp[0].gls[0]->x);//nspope; rescale *after* threads have merged
+    if(bootnSites)
+      post[j] /= double(bootnSites);
+    else
+      post[j] /= double(emp[0].gls[0]->x);//nspope; rescale *after* threads have merged
 
 #if 0
   for(int i=0;i<nThreads;i++){

--- a/misc/realSFS_optim.cpp
+++ b/misc/realSFS_optim.cpp
@@ -268,6 +268,9 @@ void emStep4(double *pre,std::vector<Matrix<T> *> &gls,double *post,size_t start
 	      inner[inc] = pre[inc]*gls[0]->mat[s][x] * gls[1]->mat[s][y] * gls[2]->mat[s][i]* gls[3]->mat[s][j];
 	      inc++;
 	    }
+      normalize(inner,dim);//nspope; normalization/addition should happen for each site
+      for(int x=0;x<dim;x++)
+        post[x] += inner[x];
     }
   }
   else{
@@ -280,13 +283,11 @@ void emStep4(double *pre,std::vector<Matrix<T> *> &gls,double *post,size_t start
 	      inner[inc] = pre[inc]*gls[0]->mat[bootstrap[s]][x] * gls[1]->mat[bootstrap[s]][y] * gls[2]->mat[bootstrap[s]][i]* gls[3]->mat[bootstrap[s]][j];
 	      inc++;
 	    }
-      
+    normalize(inner,dim);//nspope; normalization/addition should happen for each site
+    for(int x=0;x<dim;x++)
+      post[x] += inner[x];
     }
   }
-  normalize(inner,dim);
-  for(int x=0;x<dim;x++)
-    post[x] += inner[x];
-  
    
 }
 

--- a/misc/realSFS_optim.cpp
+++ b/misc/realSFS_optim.cpp
@@ -183,7 +183,6 @@ void emStep1(double *pre,std::vector< Matrix<T> * > &gls,double *post,size_t sta
    for(int x=0;x<dim;x++)
      post[x] += inner[x];
   }
-  normalize(post,dim);
  
 }
 
@@ -218,7 +217,6 @@ void emStep2(double *pre,std::vector<Matrix<T> *> &gls,double *post,size_t start
 	post[x] += inner[x];
     }
 
-  normalize(post,dim);
  
 }
 
@@ -252,7 +250,6 @@ void emStep3(double *pre,std::vector<Matrix<T> *> &gls,double *post,size_t start
    for(int x=0;x<dim;x++)
      post[x] += inner[x];
   }
-  normalize(post,dim);
    
 }
 
@@ -290,7 +287,6 @@ void emStep4(double *pre,std::vector<Matrix<T> *> &gls,double *post,size_t start
   for(int x=0;x<dim;x++)
     post[x] += inner[x];
   
-  normalize(post,dim);
    
 }
 
@@ -326,7 +322,8 @@ void emStep_master(double *post,int nThreads){
       post[j] += emp[i].post[j];
   }
   
-  normalize(post,emp[0].dim);
+  for(int j=0;j<emp[0].dim;j++)
+    post[j] /= double(emp[0].gls[0]->x);//nspope; rescale *after* threads have merged
 
 #if 0
   for(int i=0;i<nThreads;i++){


### PR DESCRIPTION
Hi,

I've found the bug that broke the EM in #197 (see there for reproducible toy example). The problem has to do with when normalization is applied in the EM step, during multithreading. In the current version of realSFS, each thread normalizes its contribution before the master joins the slaves -- at which point, the master normalizes again. This does not necessarily result in a valid EM update when multiple threads are used -- it is only a valid update if the number of sites is divisible by the number of threads, so that the number of sites per thread is the same. (This can easily be verified by fixing the number of threads in realSFS on that toy example).

Instead (to always be correct), each thread should feed its unnormalized contribution to the master, which should then "normalize" by dividing by the number of sites (here is a quick derivation of the EM update showing the correctness of this: [em.pdf](https://github.com/ANGSD/angsd/files/2793928/em.pdf)). As mentioned, if the current version realSFS is forced to use one thread (-P 1) than it will always be correct.

This multithreading-normalization issue is fixed in commit dfa107d. This corrected version of realSFS converges to the MLE of the toy example in #197 regardless of number of threads. I also fixed what is apparently an error in `emStep4` with commit b60c118, where the contribution to the update from each site gets overwritten (so that only the last site contributes to the update).

Nate