### PR TITLE
added mutual information via whichFst

### DIFF
--- a/misc/realSFS.cpp
+++ b/misc/realSFS.cpp
@@ -404,7 +404,23 @@ int fst_index(int argc,char **argv){
 
 int fst(int argc,char**argv){
   if(argc==0){
-    fprintf(stderr,"\t-> Possible options: index print\n");
+    fprintf(stderr,"realSFS fst [index|print|stats|stats2]\n");
+    fprintf(stderr,"--------------------------------------\n");
+    fprintf(stderr,"\tindex [<pop1>.saf.idx <pop2>.saf.idx ...] -sfs [<pop1-pop2>.sfs] -fstout [<prefix>] -whichFst 0\n");
+    fprintf(stderr,"\t\t-sfs     \tFlattened pairwise 2d site frequency spectra (if more than two populations, use multiple times)\n");
+    fprintf(stderr,"\t\t-fstout  \tOutput prefix\n");
+    fprintf(stderr,"\t\t-whichFst\t0: default, Fst estimator from Reynolds et al (1983) Genetics 3: 767-779\n");
+    fprintf(stderr,"\t\t         \t1: Fst estimator from Bhatia et al (2013) Genome Res 23: 1514-1521\n");
+    fprintf(stderr,"\t\t         \t2: mutual information/Shannon differentiation (not an Fst estimator)\n");
+    fprintf(stderr,"\tprint [<fstout>.fst.idx]\n");
+    fprintf(stderr,"\tstats [<fstout>.fst.idx]\n");
+    fprintf(stderr,"\tstats2 [<fstout>.fst.idx]\n");
+    fprintf(stderr,"\t\t-win     \tWindow size\n");
+    fprintf(stderr,"\t\t-step    \tStep size, e.g. shift in bp from one window to next\n");
+    fprintf(stderr,"\t\t-type    \t0: default, split genome into blocks and use the first window that has data for the entire window\n");
+    fprintf(stderr,"\t\t         \t1: use first position with data as leftmost position of first window\n");
+    fprintf(stderr,"\t\t         \t2: use first coordinate as leftmost position of first window, regardless of whether there is data\n");
+    fprintf(stderr,"Examples and output formats at www.popgen.dk/angsd/index.php/Fst\n");
     return 0;
   }
   if(!strcasecmp(*argv,"index"))  


### PR DESCRIPTION
Added option to calculate the mutual information instead of Fst, as an choice for `realSFS fst`. MI has nice properties (it is a true metric, it is additive, satisfies triangle inequality etc) which Fst does not. Some prefer MI to Fst for selection scans, demographics, etc. A reference is [here](https://www.ncbi.nlm.nih.gov/pubmed/29126564).

The MI is calculated with `-whichFst 2` flag to `realSFS fst index`. For MI, the numerator is the mutual information, and the denominator is the joint entropy: so the result with `realSFS fst stats` is the normalized mutual information -- a metric that is bounded [0,1]. Like with vanilla fst, the `print` option prints out the numerator (MI) and denominator (joint entropy) per site. Because of the additivity property, the whole weighted vs. unweighted distinction is moot. To avoid redundant code, `fst stats` still labels the output as Fst even though it is MI (and gives meaningless population branch statistics with three populations). But the initial `fst index` prints a warning to this effect.

I also changed the formatting for `realSFS fst print` to output numbers with a higher precision and switch to scientific notation if necessary. This avoids annoying round-off errors where both numerator and denominator are small.

Finally, I updated the help message for `realSFS fst` to reflect these updates and also the other options ... copying from the wiki where possible.