### PR TITLE
Fix for HTSlib linking issues (and HTSlib compilation for TravisCI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
       - libbz2-dev
 
 before_script:
-  - git clone --branch=develop git://github.com/samtools/htslib.git
+  - git clone --branch=develop --recursive git://github.com/samtools/htslib.git
   - cd htslib; make;cd ..
   - git clone --depth=5 --branch=develop git://github.com/samtools/samtools.git
   - cd samtools;make;cd ..

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC  ?= gcc
 CXX ?= g++
 
 LIBS = -lz -lm -lbz2 -llzma -lpthread -lcurl
+CRYPTOLIB = -lcrypto
 
 # Adjust $(HTSSRC) to point to your top-level htslib directory
 ifdef HTSSRC
@@ -75,7 +76,7 @@ misc: analysisFunction.o bfgs.o prep_sites.o
 	$(CXX) -MM $(CXXFLAGS) $*.cpp >$*.d
 
 angsd: version.h $(OBJ)
-	$(CXX) $(FLAGS) -o angsd *.o $(LIBS)
+	$(CXX) $(FLAGS) -o angsd *.o $(LIBS) $(CRYPTOLIB)
 
 testclean:
 	rm -rf test/sfstest/output test/tajima/output test/*.log version.h test/temp.txt

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -3,6 +3,7 @@ CC  ?= gcc
 CXX ?= g++
 
 LIBS = -lz -lm -lbz2 -llzma -lpthread -lcurl
+CRYPTOLIB = -lcrypto
 
 ifdef HTSSRC
 $(info misc-HTSSRC defined $(HTSSRC))
@@ -91,22 +92,22 @@ header.o: header.cpp header.h
 	$(CXX) $(FLAGS) -c header.cpp 
 
 smartCount:	smartCount.c  
-	$(CC) $(FLAGS) smartCount.c -lz -o smartCount -std=gnu99 -lpthread $(LIBS)
+	$(CC) $(FLAGS) smartCount.c -lz -o smartCount -std=gnu99 -lpthread $(LIBS) $(CRYPTOLIB)
 
 thetaStat:	thetaStat.cpp stats.cpp 
-	$(CXX) $(FLAGS) thetaStat.cpp -o thetaStat -lpthread $(LIBS) -lz
+	$(CXX) $(FLAGS) thetaStat.cpp -o thetaStat -lpthread $(LIBS) $(CRYPTOLIB) -lz
 
 msToGlf: msToGlf.c
-	$(CC) $(FLAGS) msToGlf.c -O3 -o msToGlf -std=gnu99 $(LIBS) -lz -lm -lbz2 -llzma -lpthread
+	$(CC) $(FLAGS) msToGlf.c -O3 -o msToGlf -std=gnu99 $(LIBS) $(CRYPTOLIB) -lz -lm -lbz2 -llzma -lpthread
 
 msHOT2glf: msHOT2glf.c
-	$(CC) $(FLAGS) msHOT2glf.c -O3 -o msHOT2glf -std=gnu99 $(LIBS)  -lz -lm -lbz2 -llzma -lpthread
+	$(CC) $(FLAGS) msHOT2glf.c -O3 -o msHOT2glf -std=gnu99 $(LIBS) $(CRYPTOLIB) -lz -lm -lbz2 -llzma -lpthread
 
 multisafreader.hpp: Matrix.hpp realSFS_shared.o 
 
 
 realSFS: realSFS.cpp safreader.o keep.hpp safstat.o realSFS_args.o header.o fstreader.o safcat.o multisafreader.hpp realSFS_optim.o realSFS_shared.o realSFS_dadi.o
-	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_shared.o ../prep_sites.o ../aio.o ../analysisFunction.o ../chisquare.o realSFS_dadi.o $(LIBS) -lz -lpthread
+	$(CXX) $(FLAGS) realSFS.cpp -o realSFS  safreader.o realSFS_args.o safstat.o fstreader.o header.o safcat.o realSFS_optim.o realSFS_shared.o ../prep_sites.o ../aio.o ../analysisFunction.o ../chisquare.o realSFS_dadi.o $(LIBS) $(CRYPTOLIB) -lz -lpthread
 
 hmm_psmc.o: hmm_psmc.cpp hmm_psmc.h compute.c
 	$(CXX) $(FLAGS) -c hmm_psmc.cpp
@@ -118,7 +119,7 @@ main_psmc.o: main_psmc.cpp main_psmc.h fpsmc.h fpsmc.o
 	$(CXX) $(FLAGS) -c main_psmc.cpp
 
 ngsPSMC: ngsPSMC.cpp psmcreader.o header.o main_psmc.o fpsmc.o  hmm_psmc.o
-	$(CXX) $(FLAGS) ngsPSMC.cpp -o ngsPSMC psmcreader.o header.o fpsmc.o main_psmc.o hmm_psmc.o ../bfgs.o $(LIBS) -lz
+	$(CXX) $(FLAGS) ngsPSMC.cpp -o ngsPSMC psmcreader.o header.o fpsmc.o main_psmc.o hmm_psmc.o ../bfgs.o $(LIBS) $(CRYPTOLIB) -lz
 
 clean:
 	rm -f *.o $(PROGRAMS) $(PROGRAMS_MISC) *~


### PR DESCRIPTION
Hi,
Firstly, thanks for all your work developing ANGSD!

I was just trying to set up ANGSD from the latest Github commit recently and ran into a few problems on two different clusters, so figured it might be worth sending a PR for some minor changes rather than just make Issues.

The problems I ran into:
1) Linking to an install of the latest HTSlib gave errors about undefined references to symbols belonging to libcrypto
2) Including libcrypto generically in `LIBS` in the two `Makefile`s resulted in undefined references to `aio::kputc`, `aio::kputs`, and `aio::kputw`, symptomatic of a namespace collision between ANGSD IO and POSIX AIO
3) Linking to HTSlib < 1.10 led to errors about functions like `sam_hdr_count_lines` not being declared (I tested with HTSlib 1.7)
4) Even the latest commit on master resulted in a failed TravisCI run, as HTSlib added htscodecs as a submodule 4 days ago, breaking the ANGSD `.travis.yml` configuration

This PR should rectify problems 1, 2, and 4.

As to problem 3, that seems like a dependency requirement that could be mentioned in a README or something (it looks like you updated those function calls in ANGSD in commit b2402d3).

Hope that helps!

Best regards,
Patrick Reilly