### PR TITLE
[fix](test) Fix smallBam link error

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -2,7 +2,7 @@ name: build-tests
 
 on:
   push:
-    branches: [ master, nspope_bandedDP ]
+    branches: [ master, nspope_bandedDP, develop ]
   pull_request:
     branches: [ master, nspope_bandedDP ]
 
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies    
       run: |
         sudo apt-get install -y libbz2-dev liblzma-dev libcurl4-openssl-dev
-        git clone --depth=5 git://github.com/ANGSD/smallBam.git
+        git clone --depth=5 https://github.com/ANGSD/smallBam.git
 
     - name: Run CMake
       run: |


### PR DESCRIPTION
Update smallBam repo link to match the new security protocol.
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Add develop to build test list.