### PR TITLE
[fix]: Replace assert statements with aio assert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 # Other files
 *.d
 angsd
+angsdput*
 misc/NGSadmix
 misc/contamination
 misc/contamination2

--- a/abcAncestry.cpp
+++ b/abcAncestry.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <ctype.h>
 #include "shared.h"
 #include "analysisFunction.h"
@@ -52,7 +51,7 @@ void abcAncestry::clean(funkyPars *pars){
 
 
 void abcAncestry::print(funkyPars *pars){
-  assert(pars->anc!=NULL);
+	aio::doAssert(pars->anc!=NULL,1,AT,"");
   if(doAncestry==1){
   
   }

--- a/abcCounts.cpp
+++ b/abcCounts.cpp
@@ -5,7 +5,6 @@
 */
 
 #include <htslib/kstring.h>
-#include <cassert>
 #include "analysisFunction.h"
 #include "abc.h"
 #include "abcCounts.h"
@@ -476,7 +475,7 @@ void abcCounts::print(funkyPars *pars){
     countQs(pars->chk,qsDist,pars->keepSites,minQ);
   
   if(doDepth!=0){
-    assert(pars->counts!=NULL);
+	  aio::doAssert(pars->counts!=NULL,1,AT,"");
     for(int s=0;s<pars->numSites;s++) {
       if(pars->keepSites[s]==0)
 	continue; 
@@ -673,7 +672,7 @@ suint **abcCounts::countNucs(const chunkyT *chk,int *keepSites,int mmin,int mmax
 void abcCounts::run(funkyPars *pars){
   if(doCounts==0)
     return;
-  assert(pars->chk!=NULL&&pars->counts==NULL);
+  aio::doAssert(pars->chk!=NULL&&pars->counts==NULL,1,AT,"");
   pars->counts = countNucs(pars->chk,pars->keepSites,setMinDepthInd,setMaxDepthInd);
   if(doebd){
     counts *cnts = new counts;

--- a/abcError.cpp
+++ b/abcError.cpp
@@ -1,6 +1,5 @@
 #include <list>
 #include <cmath>
-#include <cassert>
 #include "bfgs.h"
 #include "analysisFunction.h"
 #include "abcError.h"
@@ -420,7 +419,7 @@ void abcError::clean(funkyPars *pars){
 void abcError::run(funkyPars *pars){
   if(doError==0)
     return;
-  assert(pars->counts!=NULL);
+  aio::doAssert(pars->counts!=NULL,1,AT,"");
     
 
   //  pars->opt->emIter=emIter;

--- a/abcFilter.cpp
+++ b/abcFilter.cpp
@@ -10,7 +10,6 @@ osome if we have reached the last position from the keep list.
 Maybe there are some memleaks. This will have to be fixed later.
 */
 
-#include <cassert>
 #include <sys/stat.h>
 #include "shared.h"
 #include "abc.h"

--- a/abcFreq.cpp
+++ b/abcFreq.cpp
@@ -9,7 +9,6 @@
 
 */
 
-#include <cassert>
 #include <cmath>
 #include <htslib/kstring.h>
 #include <htslib/bgzf.h>
@@ -442,7 +441,7 @@ void abcFreq::print(funkyPars *pars) {
 
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+	  aio::doAssert(major!=4&&minor!=4,1,AT,"");
 	
       for(int i=0;i<3*pars->nInd;i++) {
 	ksprintf(&bufstr, "\t%f",pars->post[s][i]);
@@ -596,7 +595,7 @@ void abcFreq::run(funkyPars *pars) {
     }
   }
   if(doPost) {
-    assert(pars->likes!=NULL);
+	  aio::doAssert(pars->likes!=NULL,1,AT,"");
 
     double **post = new double*[pars->numSites];
     double **like=angsd::get3likes(pars);
@@ -622,7 +621,7 @@ void abcFreq::run(funkyPars *pars) {
 	   fprintf(stderr,"\t-> Problem calling genotypes at: (%s,%d)\n",header->target_name[pars->refId],pars->posi[s]+1);	   
       }
       else if(doPost==4){
-	assert(fl!=NULL);
+		aio::doAssert(fl!=NULL,1,AT,"");
 	//af for this pos: fl->af[pars->posi[s]]
 	//an for this pos: fl->an[pars->posi[s]]
 	//ac for this pos: fl->ac[pars->posi[s]]
@@ -680,7 +679,7 @@ void abcFreq::likeFreq(funkyPars *pars,freqStruct *freq){//method=1: bfgs_known 
     loglike= pars->likes;
   else
     loglike=angsd::get3likesRescale(pars);
-  assert(loglike!=NULL);
+  aio::doAssert(loglike!=NULL,1,AT,"");
 
   if(doSNP)
     freq->lrt = new double[pars->numSites];
@@ -1283,7 +1282,7 @@ double abcFreq::emFrequency(double *loglike,int numInds, int iter,double start,i
       break;
     }
     p=-999;
-    assert(p!=999);
+	aio::doAssert(p!=999,1,AT,"");
     return p;
   }
 

--- a/abcGetFasta.cpp
+++ b/abcGetFasta.cpp
@@ -9,7 +9,6 @@
   Actually no need to mutex, except for the first chunk. Lets fix it at some point.
 */
 
-#include <cassert>
 
 #include "analysisFunction.h"
 #include "shared.h"
@@ -137,7 +136,7 @@ char *abcGetFasta::loadChr(perFasta *f, char*chrName,int chrId){
 
 char *abcGetFasta::magic(int refId,int *posi,int numSites,perFasta *f){
   pthread_mutex_lock(&f->aMut);
-  assert(refId!=-1);
+  aio::doAssert(refId!=-1,1,AT,"");
   //load new chr if different from last or if nothing has been loaded before
   if(f->curChr==-1||refId!=f->curChr){
     //    fprintf(stderr,"[%s] chaning to chr: %d\n",__FUNCTION__,refId);

--- a/abcIBS.cpp
+++ b/abcIBS.cpp
@@ -6,7 +6,6 @@
   part of angsd
   NB for cov. maf > 0.001 is hardcoded (don't want the world to explode)
 */
-#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <htslib/kstring.h>
@@ -268,12 +267,12 @@ void abcIBS::printHaplo(funkyPars *pars){
   if(makeMatrix){
     for(int i=0;i<pars->nInd;i++){
       for(int j=0;j<pars->nInd;j++){
-	assert( haplo->ibsMatrix[i*pars->nInd+j] >= 0  || haplo->nonMis[i*pars->nInd+j] >= 0 );
+	aio::doAssert( haplo->ibsMatrix[i*pars->nInd+j] >= 0  || haplo->nonMis[i*pars->nInd+j] >= 0 ,1,AT,"");
 	//	  fprintf(stdout,"negative count %d\t%d\n",haplo->ibsMatrix[i*pars->nInd+j],haplo->nonMis[i*pars->nInd+j]);
 
 	ibsMatrixAll[i*pars->nInd+j] += haplo->ibsMatrix[i*pars->nInd+j];
 	nonMisAll[i*pars->nInd+j] += haplo->nonMis[i*pars->nInd+j];
-	assert(nonMisAll[i*pars->nInd+j] >= 0  || ibsMatrixAll[i*pars->nInd+j] >= 0);
+	aio::doAssert(nonMisAll[i*pars->nInd+j] >= 0  || ibsMatrixAll[i*pars->nInd+j] >= 0,1,AT,"");
       }
     }
   }

--- a/abcMajorMinor.cpp
+++ b/abcMajorMinor.cpp
@@ -28,13 +28,14 @@
 
 
 #include <cmath> //<- for log,exp
-#include <cassert>
 #include <cfloat>
 #include "shared.h"
 #include "analysisFunction.h"
 #include "abc.h"
 #include "abcMajorMinor.h"
 #include "abcFilter.h"
+#include "aio.h"
+
 static int isnaninf(double *d,int l){
   for(int i=0;i<l;i++)
     if(std::isnan(d[i])||std::isinf(d[i]))
@@ -278,7 +279,7 @@ void abcMajorMinor::majorMinorGL(funkyPars *pars,int doMajorMinor){
 	fprintf(stdout,"\t-> Something has gone wrong trying to infer major/minor from GLS at \'%s\' %d will discard site from analysis\n",header->target_name[pars->refId],pars->posi[s]+1);
 	pars->keepSites[s]=0;
       }
-      // assert(choiceMajor!=-1&&choiceMinor!=-1);
+      // aio::doAssert(choiceMajor!=-1&&choiceMinor!=-1);
       for(int i=0;i<pars->nInd;i++){
 	W0=exp(pars->likes[s][i*10+angsd::majorminor[choiceMajor][choiceMajor]])*0.25;
 	W1=exp(pars->likes[s][i*10+angsd::majorminor[choiceMajor][choiceMinor]])*0.5;
@@ -389,7 +390,7 @@ int abcMajorMinor::majorMinorEBD(funkyPars *pars,int doMajorMinor){
 }
 
 void majorMinorCounts(suint **counts,int nFiles,int nSites,char *major,char *minor,int *keepSites,int doMajorMinor,char *ref,char *anc) {
-  assert(counts!=NULL);
+  aio::doAssert(counts!=NULL,1,AT,"");
 
   for(int s=0;s<nSites;s++){
     if(keepSites==0)
@@ -517,7 +518,7 @@ void abcMajorMinor::run(funkyPars *pars){
 	continue;
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+      aio::doAssert(major!=4&&minor!=4,1,AT,"");
       
       lh3->hasAlloced[s]=1;
       lh3->lh3[s] = new double[3*pars->nInd];

--- a/abcMcall.cpp
+++ b/abcMcall.cpp
@@ -1,5 +1,5 @@
-#include <cassert>
 #include "abc.h"
+#include "aio.h"
 #include "analysisFunction.h"
 #include "shared.h"
 #include "abcMcall.h"
@@ -22,7 +22,7 @@ void abcMcall::printArg(FILE *fp){
 }
 
 void offset2allele(int a,int &b,int &c){
-  assert(a>=0&&a<10);
+  aio::doAssert(a>=0&&a<10,1,AT,"");
   if(a==0){//AA
     b=0;
     c=0;
@@ -605,8 +605,8 @@ void abcMcall::run(funkyPars *pars) {
        int b2=refToInt[DAS_BEST[1]];
        //    fprintf(stderr,"offset2allele: which=%d a1=%d a2=%d DAS: b1=%d b2=%d lk: %f nd->l: %d\n",whichmax,a1,a2,b1,b2,gc_llh[i*10+whichmax],pars->chk->nd[s][i]?pars->chk->nd[s][i]->l:0);
        if(b2!=4){
-	 assert(a1==b1||a1==b2);
-	 assert(a2==b1||a2==b2);
+	 aio::doAssert(a1==b1||a1==b2);
+	 aio::doAssert(a2==b1||a2==b2);
        }
        dat->gcdat[s][i] = -1;
        if(pars->chk->nd[s][i]&&pars->chk->nd[s][i]->l>0){

--- a/abcScounts.cpp
+++ b/abcScounts.cpp
@@ -1,5 +1,4 @@
 #include <ctype.h>
-#include <cassert>
 #include "shared.h"
 #include "analysisFunction.h"
 #include "abcScounts.h"
@@ -134,7 +133,7 @@ void abcScounts::print(funkyPars *pars){
       cnts.C = pars->counts[s][1];
       cnts.G = pars->counts[s][2];
       cnts.T = pars->counts[s][3];
-      assert(sizeof(counts)==bgzf_write(outfile,&cnts,sizeof(counts)*1));
+      aio::doAssert(sizeof(counts)==bgzf_write(outfile,&cnts,sizeof(counts)*1),1,AT,"");
       
     }
   }

--- a/aio.cpp
+++ b/aio.cpp
@@ -1,117 +1,137 @@
 #include <cstring>
+#include <stdarg.h>
 #include <sys/stat.h>
 #include "aio.h"
 
 int aio::fexists(const char* str){///@param str Filename given as a string.
-  struct stat buffer ;
-  return (stat(str, &buffer )==0 ); /// @return Function returns 1 if file exists.
+	struct stat buffer ;
+	return (stat(str, &buffer )==0 ); /// @return Function returns 1 if file exists.
 }
 
 size_t aio::fsize(const char* fname){
-  struct stat st ;
-  stat(fname,&st);
-  return st.st_size;
+	struct stat st ;
+	stat(fname,&st);
+	return st.st_size;
 }
 
 std::vector <char *> dumpedFiles;//small hack for getting a nice vector of outputfiles
 FILE *aio::openFile(const char* a,const char* b){
-  if(0)
-    fprintf(stderr,"[%s] %s %s",__FUNCTION__,a,b);
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  //  fprintf(stderr,"\t-> Dumping file: %s\n",c);
-  dumpedFiles.push_back(strdup(c));
-  FILE *fp = NULL;
-  fp = fopen(c,"w");
-  if(fp==NULL){
-    fprintf(stderr,"\t-> Problem opening file: \'%s\' check permissions\n",c);
-    exit(0);
-  }
-  delete [] c;
-  return fp;
+	if(0)
+		fprintf(stderr,"[%s] %s %s",__FUNCTION__,a,b);
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	//  fprintf(stderr,"\t-> Dumping file: %s\n",c);
+	dumpedFiles.push_back(strdup(c));
+	FILE *fp = NULL;
+	fp = fopen(c,"w");
+	if(fp==NULL){
+		fprintf(stderr,"\t-> Problem opening file: \'%s\' check permissions\n",c);
+		exit(0);
+	}
+	delete [] c;
+	return fp;
 }
 
 BGZF *aio::openFileBG(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  BGZF *fp = bgzf_open(c,"w6h");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	BGZF *fp = bgzf_open(c,"w6h");
+	delete [] c;
+	return fp;
 }
 
 htsFile *aio::openFileHts(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  htsFile *fp = hts_open(c,"w");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	htsFile *fp = hts_open(c,"w");
+	delete [] c;
+	return fp;
 }
 
 htsFile *aio::openFileHtsBcf(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  htsFile *fp = hts_open(c,"wb");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	htsFile *fp = hts_open(c,"wb");
+	delete [] c;
+	return fp;
 }
 
 FILE *aio::getFILE(const char*fname,const char* mode){
-  int writeFile = 0;
-  for(size_t i=0;i<strlen(mode);i++)
-    if(mode[i]=='w')
-      writeFile = 1;
-  FILE *fp;
-  if(NULL==(fp=fopen(fname,mode))){
-    fprintf(stderr,"\t-> Error opening FILE handle for file:%s exiting\n",fname);
-    exit(0);
-  }
-  return fp;
+	int writeFile = 0;
+	for(size_t i=0;i<strlen(mode);i++)
+		if(mode[i]=='w')
+			writeFile = 1;
+	FILE *fp;
+	if(NULL==(fp=fopen(fname,mode))){
+		fprintf(stderr,"\t-> Error opening FILE handle for file:%s exiting\n",fname);
+		exit(0);
+	}
+	return fp;
 }
 
 //checks that newer is newer than older
 int aio::isNewer(const char *newer,const char *older){
-   if (strstr(older, "ftp://") == older || strstr(older, "http://") == older)
-     return 0;
-  //  fprintf(stderr,"newer:%s older:%s\n",newer,older);
-  // return 0;
-  struct stat one;
-  struct stat two;
-  stat(newer, &one );
-  stat(older, &two );
-  
-  return one.st_mtime>=two.st_mtime;
+	if (strstr(older, "ftp://") == older || strstr(older, "http://") == older)
+		return 0;
+	//  fprintf(stderr,"newer:%s older:%s\n",newer,older);
+	// return 0;
+	struct stat one;
+	struct stat two;
+	stat(newer, &one );
+	stat(older, &two );
+
+	return one.st_mtime>=two.st_mtime;
 }
 
 ssize_t aio::bgzf_write(BGZF *fp, const void *data, size_t length){
-  if(length>0)
-    return ::bgzf_write(fp,data,length);
-  return 0;
+	if(length>0)
+		return ::bgzf_write(fp,data,length);
+	return 0;
 }
 
 
 int aio::tgets(gzFile gz,char**buf,int *l){
-  int rlen = 0;
- neverUseGoto:
-  char *tok = gzgets(gz,*buf+rlen,*l-rlen);
-  if(!tok)
-    return rlen;
-  int tmp = tok?strlen(tok):0;
-  if(tok[tmp-1]!='\n'){
-    rlen += tmp;
-    *l *= 2;
-    *buf = (char*) realloc(*buf,*l);
-    goto neverUseGoto;
-  }
-  rlen += tmp;
-  return rlen;
+	int rlen = 0;
+neverUseGoto:
+	char *tok = gzgets(gz,*buf+rlen,*l-rlen);
+	if(!tok)
+		return rlen;
+	int tmp = tok?strlen(tok):0;
+	if(tok[tmp-1]!='\n'){
+		rlen += tmp;
+		*l *= 2;
+		*buf = (char*) realloc(*buf,*l);
+		goto neverUseGoto;
+	}
+	rlen += tmp;
+	return rlen;
 }
+
+//  Usage: aio::doAssert(something==NULL,1,AT,"");
+void aio::doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...){
+	if(EXIT){
+		va_list args;
+		va_start (args, format);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		fprintf(stderr, "[ERROR](%s)\n",error_location);
+		vfprintf (stderr, format, args);
+		va_end (args);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		exit(EXIT_CODE);
+	}else{
+		return;
+	}
+}
+

--- a/aio.h
+++ b/aio.h
@@ -3,6 +3,11 @@
 #include <htslib/kstring.h>
 #include <htslib/hts.h>
 #include <zlib.h>
+
+#define STRINGIFY(x) #x
+#define ASSTR(x) STRINGIFY(x)
+#define AT __FILE__ ":" ASSTR(__LINE__)
+
 //angsd io
 namespace aio{
   size_t fsize(const char* fname);
@@ -15,4 +20,5 @@ namespace aio{
   int isNewer(const char *newer,const char *older);
   ssize_t bgzf_write(BGZF *fp, const void *data, size_t length);
   int tgets(gzFile gz,char**buf,int *l);
+  void doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...);
 }

--- a/ancestral_likes.cpp
+++ b/ancestral_likes.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cmath>
 #include <cstdlib>   /* atoi */
 #include <cstring>
@@ -18,6 +17,7 @@
 #include "ancestral_likes.h"
 #include "analysisFunction.h"
 
+#include "aio.h"
 
 extern int refToInt[256];
 const int PRIMES = 3;
@@ -340,9 +340,9 @@ void anc_likes::gen_counts(const chunkyT *chk, count_mat *count_mat_sample,
 }
 
 void anc_likes::run(chunkyT *chk, double **lk, char *refs, char *ancs, int *keepSites, int trim){
-  assert(chk!=NULL);
+  aio::doAssert(chk!=NULL,1,AT,"");
   if(doRecal==1){
-    assert(myMuts!=NULL);
+    aio::doAssert(myMuts!=NULL,1,AT,"");
 
     if(refs==NULL){
       fprintf(stderr,"\t-> Must supply -ref (reference) for ancestral matrix generation\n");

--- a/angsd.cpp
+++ b/angsd.cpp
@@ -9,7 +9,6 @@
 */
 
 #include "version.h"
-#include <cassert>
 #include <iostream>//for printing time
 #include <cstring> //for cstring functions
 #include <cstdlib> //for exit()
@@ -20,6 +19,7 @@
 #include "shared.h"
 #include "argStruct.h"
 #include "multiReader.h"
+#include "aio.h"
 
 
 extern std::vector <char *> dumpedFiles;
@@ -221,8 +221,8 @@ int main(int argc, char** argv){
    parseArgStruct(args);
    
    //Below is main loop which will run until nomore data
-   assert(args->hd);
-   assert(args->revMap);
+   aio::doAssert(args->hd==NULL,1,AT,"");
+   aio::doAssert(args->revMap==NULL,1,AT,"");
 
    extern int cigstat;
    if(cigstat)

--- a/argStruct.cpp
+++ b/argStruct.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <libgen.h>//for checking if output dir exists 'dirname'
 #include <fstream>
 #include "version.h"
@@ -191,7 +190,7 @@ argStruct *setArgStruct(int argc,char **argv) {
   arguments->nReads = 50;
   arguments->sm=NULL;
   arguments->sm=bam_smpl_init();
-  assert(arguments->sm);
+  aio::doAssert(arguments->sm==NULL,1,AT,"");
  
   arguments->usedArgs= new int[argc+1];//well here we allocate one more than needed, this is only used in the ./angsd -beagle version
   for(int i=0;i<argc;i++)
@@ -305,7 +304,7 @@ char* angsd::getArg(const char* argName, const char* type,argStruct *arguments){
     }
     argPos++;
   }
-  //assert(0==1);
+  //aio::doAssert(0==1);
   //  fprintf(stderr,"post %p\n",type);
   return NULL;
   

--- a/bam_likes.cpp
+++ b/bam_likes.cpp
@@ -9,9 +9,10 @@
 #include <stdint.h>
 #include <cstdlib>
 #include <cmath>
-#include <cassert>
 #include <ctype.h>
 #include "mUpPile.h"
+
+#include "aio.h"
 
 extern int refToInt[256];
 #define ERR_DEP 0.83f
@@ -290,7 +291,7 @@ void call_bam(chunkyT *chk,double **lk,int trim,int *keepSites){
       bam_likes_destroy();
     return;
   }
-  assert(mod!=NULL);
+  aio::doAssert(mod!=NULL,1,AT,"");
   for(int s=0;s<chk->nSites;s++){
     lk[s] = new double[10*chk->nSamples];
     if(keepSites[s]==0)

--- a/bammer_main.cpp
+++ b/bammer_main.cpp
@@ -195,7 +195,7 @@ bufReader initBufReader2(const char*fname,int doCheck,char *fai_fname,bam_sample
 	    fprintf(stderr,"\t-> [READGROUP info] Problems adding readgroup: %s for lib: %s\n",rgs_to_add[i],it2->first);
 	  else{
 	    int tmp;
-	    assert(khash_str2int_get(rghash,rgs_to_add[i],&tmp)==0);
+	    aio::doAssert(khash_str2int_get(rghash,rgs_to_add[i],&tmp)==0,1,AT,"");
 	    fprintf(stderr,"\t-> [READGROUP info] Added readgroup %s for lib: %s (check: %s) -> %d\n",rgs_to_add[i],it2->first,it->first,tmp);
 	    if(tmp>254){
 	      fprintf(stderr,"\t-> Readgroup representation is only valid for fewer than 255 different readgroups\n");

--- a/beagleReader.cpp
+++ b/beagleReader.cpp
@@ -1,5 +1,4 @@
 
-#include <cassert>
 #include "analysisFunction.h"
 #include "beagleReader.h"
 #include "aio.h"
@@ -50,7 +49,7 @@ beagle_reader::beagle_reader(gzFile gz_a,const aMap *revMap_a,int intName_a,int 
 void parsepost(char *buffer,double *post,int nInd,const char *delims){
 	for(int i=0;i<nInd*3;i++){
 		char *tsk = strtok_r(NULL,delims,&buffer);
-		assert(tsk!=NULL);
+		aio::doAssert(tsk!=NULL,1,AT,"");
 		post[i] = atof(tsk);
 	}
 }

--- a/bgenReader.h
+++ b/bgenReader.h
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include <cstring>
-#include <cassert>
 
+#include "aio.h"
 #include "argStruct.h"
 #include "analysisFunction.h"
 #include "shared.h"
@@ -61,11 +61,11 @@ public:
   bgenReader(char *fname, const aMap *revMap_a,  int intName_a,int &nInd_a){
 
     FILE *fp=fopen(fname,"rb");
-    assert(fp!=NULL);
+    aio::doAssert(fp!=NULL,1,AT,"");
 
     unsigned offset;
     //unsigned is 4 bytes
-    assert(fread(&offset,sizeof(unsigned),1,fp)==1);
+    aio::doAssert(fread(&offset,sizeof(unsigned),1,fp)==1,1,AT,"");
     
     //read header function
     hd = parseheader(fp);

--- a/chisquare.cpp
+++ b/chisquare.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <limits>
 #include <cstdio>
-#include <cassert>
 #include "chisquare.h"
+#include "aio.h"
 
 using namespace chisq;
 /*
@@ -190,7 +190,7 @@ int main(int argc, char **argv){
   double df;
   std::cout << "Type degrees of freedom"<<std::endl;
   std::cin >> df;
-  assert(df>0);
+  aio::doAssert(df>0,1,AT,"");
   int type =0;
   
   std::cout << "Type 1-3.\n\t1: density (R::dchisq)\n\t2: cdf (R::pchisq)\n\t3: invcdf (R::qchisq)"<<std::endl;

--- a/cigstat.cpp
+++ b/cigstat.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <htslib/hts.h>
@@ -55,7 +54,7 @@ int cum =0;
       int opCode = cigs[i]&BAM_CIGAR_MASK; //what to do
       int opLen = cigs[i]>>BAM_CIGAR_SHIFT; //length of what to do
 for(int s=0;s<opLen;s++){
-  assert(s+cum<1024);
+  aio::doAssert(s+cum<1024,1,AT,"");
 cig_counts[opCode][s+cum]++;
 }
 cum += opLen;
@@ -79,7 +78,7 @@ int cigstat_close(){
       ksprintf(ks,"\t%lu",cig_counts[ncig][p]);
   }
   ksprintf(ks,"\n");
-  assert(ks->l==bgzf_write(bg,ks->s,ks->l));
+  aio::doAssert(ks->l==bgzf_write(bg,ks->s,ks->l),1,AT,"");
   bgzf_close(bg);
   return 0;
 }

--- a/glfReader.cpp
+++ b/glfReader.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "glfReader.h"
 #include <cfloat>
 

--- a/glfReader_text.cpp
+++ b/glfReader_text.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "analysisFunction.h"
 #include "glfReader_text.h"
 #include "aio.h"
@@ -21,7 +20,7 @@ glfReader_text::glfReader_text(int nInd_a,gzFile gz_a,const aMap *revMap_a){
 void parselikes10(char *buffer,double *likes,int nInd,const char *delims){
   for(int i=0;i<nInd*10;i++){
     char *tsk = strtok_r(NULL,delims,&buffer);
-    assert(tsk!=NULL);
+    aio::doAssert(tsk!=NULL,1,AT,"");
     likes[i] = atof(tsk);
   }
   

--- a/mUpPile.cpp
+++ b/mUpPile.cpp
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <ctype.h>
 #include <pthread.h>
-#include <cassert>
 #include <htslib/hts.h>
 #include <htslib/khash_str2int.h>
 #include "mUpPile.h"
@@ -64,7 +63,7 @@ typedef struct{
 
 template<typename T>
 T getmax(const T *ary,size_t len){
-  assert(len>0&&ary!=NULL);
+  aio::doAssert(len>0&&ary!=NULL,1,AT,"");
       
   T high = ary[0];
   for(size_t i=1;i<len;i++){
@@ -600,7 +599,7 @@ nodePool mkNodes_one_sampleb(readPool *sgl,nodePool *np,abcGetFasta *gf) {
     np->nds = new node[np->m];
   }
   np->l=0;
-  assert(regionLen-lastSecureIndex+4<=np->m);
+  aio::doAssert(regionLen-lastSecureIndex+4<=np->m,1,AT,"");
   for(int i=lastSecureIndex;i<regionLen;i++)
     np->nds[np->l++] = nds[i];
 
@@ -651,7 +650,7 @@ nodePoolT mkNodes_one_sampleTb(readPool *sgl,nodePoolT *np,int refID) {
     if(rghash!=NULL){
       uint8_t *rg = bam_aux_get(rd, "RG");
       if(rg)
-	assert(khash_str2int_get(rghash, (const char*)(rg+1), &thisrg)==0);
+	aio::doAssert(khash_str2int_get(rghash, (const char*)(rg+1), &thisrg)==0,1,AT,"");
     }
     
     if(rd->core.tid!=refID){
@@ -832,7 +831,7 @@ nodePoolT mkNodes_one_sampleTb(readPool *sgl,nodePoolT *np,int refID) {
     kroundup32(np->m);
     np->nds =(tNode**) realloc(np->nds,np->m*sizeof(tNode*));
   }
-  assert(regionLen-lastSecureIndex+4<=np->m);
+  aio::doAssert(regionLen-lastSecureIndex+4<=np->m,1,AT,"");
   //  fprintf(stderr,"np->m:%d\n",np->m)
   np->l=0;
   for(int i=lastSecureIndex;i<regionLen;i++)
@@ -962,7 +961,7 @@ chunkyT *mergeAllNodes_new(nodePoolT *dn,int nFiles) {
   get_span_all_samplesT(dn,nFiles,first,last);
 
   int rlen = last-first+1;
-  assert(rlen>=0);
+  aio::doAssert(rlen>=0,1,AT,"");
   if(rlen>BUG_THRES)
     return slow_mergeAllNodes_new(dn,nFiles);
 
@@ -1073,8 +1072,8 @@ chunky *slow_mergeAllNodes_old(nodePool *dn,int nFiles){
 chunky *mergeAllNodes_old(nodePool *dn,int nFiles) {
   int first,last;
   get_span_all_samples(dn,nFiles,first,last);
-  assert(first!=-1);
-  assert(last!=-1);
+  aio::doAssert(first!=-1,1,AT,"");
+  aio::doAssert(last!=-1,1,AT,"");
   int rlen = last-first+1; 
 
   if(rlen>BUG_THRES) 
@@ -1103,7 +1102,7 @@ chunky *mergeAllNodes_old(nodePool *dn,int nFiles) {
     for( i=0;((i<sm.l)&&(sm.nds[i].refPos <= std::min(sm.last,last) ));i++) {
       
       int posi = sm.nds[i].refPos-offs;
-      assert(posi>=0);
+      aio::doAssert(posi>=0,1,AT,"");
       if(depth[posi]==0){
 	super[posi] = new node[nFiles];
 	for(int ii=0;ii<nFiles;ii++){
@@ -1173,7 +1172,7 @@ int getSglStop5(readPool *sglp,int nFiles,int pickStop) {
       for(int i=0;i<nFiles;i++)
 	if(sglp[i].l>0&&(getmax(sglp[i].first,sglp[i].l)<lowestStart))
 	  lowestStart = getmax(sglp[i].first,sglp[i].l);
-      assert(lowestStart!=pickStop);
+      aio::doAssert(lowestStart!=pickStop,1,AT,"");
     }
 
   lowestStart--;
@@ -1218,7 +1217,7 @@ void getMaxMax2(readPool *sglp,int nFiles,nodePool *nps){
       if(nps[i].last>last_bp_in_chr)
 	last_bp_in_chr = nps[i].last;
     }
-    //  assert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
+    //  aio::doAssert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
     for(int i=0;i<nFiles;i++){
       sglp[i].lowestStart = last_bp_in_chr;
       sglp[i].readIDstop=sglp[i].l;
@@ -1243,7 +1242,7 @@ void getMaxMax2(readPool *sglp,int nFiles,nodePoolT *nps){
     if(nps[i].last>last_bp_in_chr)
       last_bp_in_chr = nps[i].last;
   }
-  //  assert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
+  //  aio::doAssert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
   for(int i=0;i<nFiles;i++){
     sglp[i].lowestStart = last_bp_in_chr;
     sglp[i].readIDstop=sglp[i].l;
@@ -1369,7 +1368,7 @@ void destroy_tnode_pool(){
 //Most likely this can be written more beautifull by using templated types. But to lazy now.
 int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector<regs> &regions,abcGetFasta *gf) {
   
-  assert(nLines&&nFiles);
+  aio::doAssert(nLines&&nFiles,1,AT,"");
   fprintf(stderr,"\t-> Parsing %d number of samples \n",nFiles);
   fflush(stderr);
   if(show!=1)
@@ -1464,7 +1463,7 @@ int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector
 
     if(theRef==rd[0].hdr->n_targets)
       break;
-    assert(theRef>=0 && theRef<rd[0].hdr->n_targets);//ref should be inrange [0,#nref in header]
+    aio::doAssert(theRef>=0 && theRef<rd[0].hdr->n_targets,1,AT,"");//ref should be inrange [0,#nref in header]
 
     //load fasta for this ref if needed
     void waiter(int);
@@ -1599,7 +1598,7 @@ int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector
       if(show){
 	//merge the perFile upnodes.FIXME for large regions (with gaps) this will allocate to much...
 	chunky *chk =mergeAllNodes_old(dn,nFiles);
-	assert(chk->refPos[0]<=regStop);
+	aio::doAssert(chk->refPos[0]<=regStop,1,AT,"");
 	
 	chk->regStart = regStart;
 	chk->regStop = regStop;

--- a/makeReadPool.cpp
+++ b/makeReadPool.cpp
@@ -1,4 +1,5 @@
 #include "makeReadPool.h"
+#include "aio.h"
 #define bam_dup(b) bam_copy1(bam_init1(), (b))
 readPool makePoolb(int l){
   readPool ret;
@@ -38,7 +39,7 @@ void realloc(readPool *ret,int l){
 void read_reads_usingStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int refToRead,hts_itr_t *itr,int stop,int &rdObjEof,int &rdObjRegionDone,bam_hdr_t *hdr) {
 
   //if should never be in this function if we shouldnt read from the file.
-  assert(rdObjRegionDone!=1 &&rdObjEof!=1 );
+  aio::doAssert(rdObjRegionDone!=1 &&rdObjEof!=1 ,1,AT,"");
   
   if((nReads+ret.l)>ret.m)
     realloc(&ret,nReads+ret.l);
@@ -132,7 +133,7 @@ void read_reads_usingStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int re
 void read_reads(htsFile *fp,int nReads,int &isEof,readPool &ret,int refToRead,hts_itr_t *itr,int stop,int &rdObjEof,int &rdObjRegionDone,bam_hdr_t *hdr) {
   // fprintf(stderr,"stop:%d nreads:%d reftoread:%d ret.m:%d ret.l:%d\n",stop,nReads,refToRead,ret.m,ret.l);
   //if should never be in this function if we shouldnt read from the file.
-  assert(rdObjRegionDone!=1 &&rdObjEof!=1 );
+  aio::doAssert(rdObjRegionDone!=1 &&rdObjEof!=1 ,1,AT,"");
   
 
   /*
@@ -192,7 +193,7 @@ void read_reads_noStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int refTo
 #if 0
   fprintf(stderr,"\t->[%s] buffRefid=%d\trefToRead=%d\n",__FUNCTION__,ret.bufferedRead.refID,refToRead);
 #endif
-  assert(rdObjEof==0 && ret.bufferedRead ==NULL);
+  aio::doAssert(rdObjEof==0 && ret.bufferedRead ==NULL,1,AT,"");
  
   if((nReads+ret.l)>ret.m)
     realloc(&ret,nReads+ret.l);

--- a/makeReadPool.h
+++ b/makeReadPool.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <cstdlib>
 #include <htslib/hts.h>
 #include <htslib/sam.h>

--- a/mpileup.cpp
+++ b/mpileup.cpp
@@ -1,5 +1,4 @@
 #include <ctype.h>
-#include <cassert>
 #include "pooled_alloc.h"
 #include "mpileup.h"
 #include "mUpPile.h"
@@ -31,7 +30,7 @@ tNode **parseNd(char *line,int nInd,const char *delims,int minQ,char ref){
   for(int i=0;i<nInd;i++) {
 
     char *tok = strtok_r(NULL,delims,&line);
-    assert(tok);
+    aio::doAssert(tok==NULL,1,AT,"");
     int seqDepth = atoi(tok);
     ret[i] = initNodeT(seqDepth);
     ret[i]->l = seqDepth;

--- a/multiReader.cpp
+++ b/multiReader.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "abc.h"
 #include "shared.h"
 #include "multiReader.h"
@@ -44,7 +43,7 @@ bam_hdr_t *getHeadFromFai(const char *fname){
 }
 
 aMap *buildRevTable(const bam_hdr_t *hd){
-  assert(hd);
+  aio::doAssert(hd==NULL,1,AT,"");
   aMap *ret = new aMap;
   for(int i=0;i<hd->n_targets;i++){
     ret->insert(std::pair<char *,int>(strdup(hd->target_name[i]),i));

--- a/pop1_read.cpp
+++ b/pop1_read.cpp
@@ -9,7 +9,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cassert>
 #include <ctype.h>
 #include <cmath>
 #include <htslib/hts.h>
@@ -19,6 +18,7 @@
 #include "abcGetFasta.h"
 #include "cigstat.h"
 #include "from_samtools.h"
+#include "aio.h"
 
 //three externs below are from
 extern int uniqueOnly;
@@ -62,16 +62,16 @@ int getNumBest(bam1_t *b) {
 int restuff(bam1_t *b){
   //  fprintf(stderr,"ohh yes: b.refID=%d b.pos=%d\n",b.refID,b.pos);
  extern abcGetFasta *gf;
- assert(gf->ref->curChr==b->core.tid);
+ aio::doAssert(gf->ref->curChr==b->core.tid,1,AT,"");
 
  if(baq){
-   assert(gf->ref!=NULL);
-   assert(gf->ref->curChr==b->core.tid);
+   aio::doAssert(gf->ref!=NULL,1,AT,"");
+   aio::doAssert(gf->ref->curChr==b->core.tid,1,AT,"");
    sam_prob_realn(b,gf->ref->seqs,gf->ref->chrLen,baq);
  }
 
  if(adjustMapQ!=0){
-   assert(gf->ref!=NULL);
+   aio::doAssert(gf->ref!=NULL,1,AT,"");
    int q = sam_cap_mapq(b,gf->ref->seqs,gf->ref->chrLen,adjustMapQ);
    if(q<0)
      return 0;
@@ -139,7 +139,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
     if(uniqueOnly==0&&only_proper_pairs==0 &&remove_bads==0&&minMapQ==0&&adjustMapQ==0&&baq==0){
       //fprintf(stderr,"r:%d\n",r);
       if(cigstat)
-	assert(cigstat_calc(b)==0);
+	aio::doAssert(cigstat_calc(b)==0,1,AT,"");
       return r;
     }
     
@@ -163,7 +163,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
     
     if(gf->ref!=NULL&&gf->ref->curChr==b->core.tid){
       if(adjustMapQ!=0){
-	assert(gf->ref!=NULL);
+	aio::doAssert(gf->ref!=NULL,1,AT,"");
 	int q = sam_cap_mapq(b,gf->ref->seqs,gf->ref->chrLen,adjustMapQ);
 	if(q<0)
 	  goto bam_iter_reread;
@@ -177,7 +177,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
   }
   // fprintf(stderr,"r:%d\n",r);
   if(cigstat)
-    assert(cigstat_calc(b)==0);
+    aio::doAssert(cigstat_calc(b)==0,1,AT,"");
   return r; 
 }
 

--- a/prep_sites.cpp
+++ b/prep_sites.cpp
@@ -5,13 +5,14 @@
   g++ prep_sites.cpp -D__WITH_MAIN__ bgzf.o knetfile.o -lz analysisFunction.o -ggdb
 */
 
+
+
 #ifdef __WITH_MAIN__
 #endif
 
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include <cassert>
 #define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 #include "prep_sites.h"
 #include "aio.h"
@@ -45,7 +46,7 @@ void dalloc(tary<T> *ta){
 
 //hint is the suggested newsize
 void filt_readSites(filt*fl,char *chr,size_t hint) {
-  assert(fl!=NULL);
+  aio::doAssert(fl!=NULL, 1, AT,"fl is null");
 
   std::map<char*,asdf_dats,ltstr> ::iterator it = fl->offs.find(chr);
   if(it==fl->offs.end()){
@@ -66,7 +67,7 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
     return;
   }
 
-  assert(0==bgzf_seek(fl->bg,it->second.offs,SEEK_SET));
+  aio::doAssert(0==bgzf_seek(fl->bg,it->second.offs,SEEK_SET),1,AT,"0==bgzf_seek");
 
   size_t nsize = std::max(fl->curLen,hint);//this is not the number of elements, but the last position on the reference
   nsize = std::max(nsize,it->second.len)+1;//not sure if '+1' this is needed, but it doesnt hurt...
@@ -75,7 +76,7 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
     fl->keeps=(char*) realloc(fl->keeps,nsize);
   memset(fl->keeps,0,nsize);
   //fprintf(stderr,"it->second.len:%lu fl->curLen:%lu fl->keeps:%p\n",it->second.len,fl->curLen,fl->keeps);
-  assert(it->second.len==bgzf_read(fl->bg,fl->keeps,it->second.len));
+  aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->keeps,it->second.len),1,AT,"");
 
   if(fl->hasExtra>0){
     if(nsize>fl->curLen) {
@@ -84,8 +85,8 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
       memset(fl->major,0,nsize);
       memset(fl->minor,0,nsize);
     }
-    assert(it->second.len==bgzf_read(fl->bg,fl->major,it->second.len));
-    assert(it->second.len==bgzf_read(fl->bg,fl->minor,it->second.len));
+    aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->major,it->second.len),1,AT,"");
+    aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->minor,it->second.len),1,AT,"");
   }
   if(fl->hasExtra>1){
     if(nsize>fl->curLen) {
@@ -96,9 +97,9 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
       memset(fl->an,0,nsize*sizeof(int));
       memset(fl->ac,0,nsize*sizeof(int));
     }
-    assert(it->second.len*sizeof(float)==bgzf_read(fl->bg,fl->af,it->second.len*sizeof(float)));
-    assert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->ac,it->second.len*sizeof(int)));
-    assert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->an,it->second.len*sizeof(int)));
+    aio::doAssert(it->second.len*sizeof(float)==bgzf_read(fl->bg,fl->af,it->second.len*sizeof(float)),1,AT,"");
+    aio::doAssert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->ac,it->second.len*sizeof(int)),1,AT,"");
+    aio::doAssert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->an,it->second.len*sizeof(int)),1,AT,"");
   }
 
   fl->curNam=chr;
@@ -287,7 +288,7 @@ typedef std::map<char *,int,ltstr> mmap;
 
 //return zero if fine.
 int writeDat(char *last,mmap &mm,tary<char> *keep,tary<char> *major,tary<char> *minor,BGZF *BFP,FILE *fp,int doCompl,tary<float> *af,tary<int> *ac,tary<int> *an){
-  assert(last!=NULL);
+  aio::doAssert(last!=NULL,1,AT,"last is null");
   if((major!=NULL) ^ (minor!=NULL)){
     fprintf(stderr,"major and minor should be the same\n");
     return 1;
@@ -304,7 +305,7 @@ int writeDat(char *last,mmap &mm,tary<char> *keep,tary<char> *major,tary<char> *
   }else
     mm[strdup(last)]=1;
   //write data and index stuff
-  assert(0==bgzf_flush(BFP));
+  aio::doAssert(0==bgzf_flush(BFP),1,AT,"bgzf_flush!=0");
   int64_t retVal =bgzf_tell(BFP);//now contains the offset to which we should point.
   
   //write chrname
@@ -442,15 +443,15 @@ void filt_gen(const char *fname,int posi_off,int doCompl) {
 	memset(minor->d,4,keep->m);
 	major->l=minor->l=0;
       }
-      if(hasExtra>1)
-	assert(1);
+      // if(hasExtra>1)
+
     }
     char *position_in_sites_file = parsed[1];
-    assert(atol(position_in_sites_file)>=0);
+    aio::doAssert(atol(position_in_sites_file)>=0,1,AT,"");
     size_t posS=atol(parsed[1]);
     if(posS<=0){
       fprintf(stderr,"\t-> Problem surrounding line: %d\n",atline);
-      assert(posS>0);
+      aio::doAssert(posS>0,1,AT,"posS>0");
     }
     posS--;
     posS += posi_off;

--- a/shared.cpp
+++ b/shared.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <pthread.h>
-#include <cassert>
 #include <errno.h>
 #include "bambi_interface.h"
 #include "shared.h"

--- a/simple_likes.cpp
+++ b/simple_likes.cpp
@@ -5,10 +5,10 @@
 
 #include <cmath>
 #include <cstdio>
-#include <cassert>
 #include "bambi_interface.h"
 #include "simple_likes.h"
 #include "analysisFunction.h"
+#include "aio.h"
 
 double **probs_simple = NULL;
 
@@ -73,7 +73,7 @@ void call_simple(suint **counts,int *keepSites,double **lk,int nSites,int nSampl
 
       int r = angsd::getRandomCount(counts[s],i,-1);
       //      fprintf(stdout,"ris\t%d\n",r);
-      assert(r>-1);
+      aio::doAssert(r>-1,1,AT,"");
       if(r==4)
 	continue;
       for(int j=0;j<10;j++){

--- a/soap_likes.cpp
+++ b/soap_likes.cpp
@@ -15,7 +15,6 @@
 #include <sys/stat.h>//mkdir
 #include <sys/types.h>//mkdir
 #include <vector>
-#include <cassert>
 #include <limits> //<- for setting nan
 #include <ctype.h>
 #include <cstdlib>
@@ -359,8 +358,8 @@ void dump_count_mat(const char *fname,size_t *count_mat){
 
 
 void soap_likes::run(chunkyT *chk,double **lk,char *refs,int trim) {
-  assert(myMuts!=NULL);
-  assert(chk!=NULL);
+  aio::doAssert(myMuts!=NULL,1,AT,"");
+  aio::doAssert(chk!=NULL,1,AT,"");
 
   if(doRecal==0){
     for(int i=0;i<chk->nSamples  ;i++)

--- a/vcfReader.cpp
+++ b/vcfReader.cpp
@@ -3,11 +3,11 @@
 #include <cmath>
 #include <string>
 #include <errno.h>
-#include <cassert>
 #include <inttypes.h>
 #include <cstdlib>
 #include "analysisFunction.h"
 #include "vcfReader.h"
+#include "aio.h"
 
 bam_hdr_t *bcf_hdr_2_bam_hdr_t (htsstuff *hs){
   bam_hdr_t *ret = bam_hdr_init();
@@ -50,7 +50,7 @@ bam_hdr_t *bcf_hdr_2_bam_hdr_t (htsstuff *hs){
 }
 
 void htsstuff_seek(htsstuff *hs,char *seek){
-  assert(seek);
+  aio::doAssert(seek==NULL,1,AT,"");
   if(seek){
     fprintf(stderr,"\t-> Setting iterator to: %s\n",seek);fflush(stderr);
     if(hs->idx==NULL)
@@ -67,7 +67,7 @@ void htsstuff_seek(htsstuff *hs,char *seek){
     if(hs->iter)
       hts_itr_destroy(hs->iter);
     hs->iter=bcf_itr_querys(hs->idx,hs->hdr,seek);
-    assert(hs->iter);
+    aio::doAssert(hs->iter==NULL,1,AT,"");
   }
 }
 
@@ -83,10 +83,10 @@ htsstuff *htsstuff_init(char *fname,char *seek){
   hs->iter=NULL;
   hs->nsamples = 0;
   hs->hts_file=hts_open(hs->fname,"r");
-  assert(hs->hts_file);
+  aio::doAssert(hs->hts_file==NULL,1,AT,"");
   
   hs->hdr = bcf_hdr_read(hs->hts_file);
-  assert(hs->hdr);
+  aio::doAssert(hs->hdr==NULL,1,AT,"");
 
   hs->nsamples = bcf_hdr_nsamples(hs->hdr);
   if(hs->seek)
@@ -208,7 +208,7 @@ int whichisindel(const bcf_hdr_t *h){
 int isindel(const bcf_hdr_t *h, const bcf1_t *v){
   bcf_unpack((bcf1_t*)v, BCF_UN_ALL);
   static int hit = whichisindel(h);//only calculated once
-  //  assert(hit!=-1);//we assume INDEL exists in INFO field
+  //  aio::doAssert(hit!=-1);//we assume INDEL exists in INFO field
   if(hit==-1)
     return 0;
   int returnvalue = 0;
@@ -236,7 +236,7 @@ int isindel(const bcf_hdr_t *h, const bcf1_t *v){
 
 int dumpcounterverbose[2] = {0,0};
 int vcfReader::parseline(bcf1_t *rec,htsstuff *hs,funkyPars *r,int &balcon,int type){
-  assert(type>=0&&type<=2);
+  aio::doAssert(type>=0&&type<=2,1,AT,"");
   int n;
   if(isindel(hs->hdr,rec)!=0)
     return 0;
@@ -361,7 +361,7 @@ int vcfReader::parseline(bcf1_t *rec,htsstuff *hs,funkyPars *r,int &balcon,int t
   if(type==0||type==1){
     if(n>=0){//case where we have data
      // fprintf(stderr,"data\n");
-      assert((n % hs->nsamples)==0 );
+      aio::doAssert((n % hs->nsamples)==0 ,1,AT,"");
       int myofs=n/hs->nsamples;
       for(int ind=0;ind<hs->nsamples;ind++){
 	int rollback =0;


### PR DESCRIPTION
Add function aio::doAssert to replace asserts
Did not use aio::assert as name since aio.h
namespace complains due to assert being a macro


* Fixes the major bug explained in #527
* Fixes issues #520 #474 #466 #420 #405 #396 #385
* Possibly others too; other issues should rerun the
commands using the latest version.