### PR TITLE
[fix]: Fix assert bug related to DNDEBUG flags #527

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 # Other files
 *.d
 angsd
+angsdput*
 misc/NGSadmix
 misc/contamination
 misc/contamination2

--- a/abcAncestry.cpp
+++ b/abcAncestry.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <ctype.h>
 #include "shared.h"
 #include "analysisFunction.h"
@@ -52,7 +51,7 @@ void abcAncestry::clean(funkyPars *pars){
 
 
 void abcAncestry::print(funkyPars *pars){
-  assert(pars->anc!=NULL);
+	aio::doAssert(pars->anc!=NULL,1,AT,"");
   if(doAncestry==1){
   
   }

--- a/abcCallGenotypes.cpp
+++ b/abcCallGenotypes.cpp
@@ -3,7 +3,6 @@
   class to call genotypes
 */
 
-#include <assert.h>
 #include <htslib/kstring.h>
 #include "shared.h"
 
@@ -189,7 +188,7 @@ void abcCallGenotypes::getGeno(funkyPars *pars){
 
 void abcCallGenotypes::printGeno(funkyPars *pars){
   genoCalls *geno =(genoCalls *) pars->extras[index];
-  assert(pars->keepSites!=NULL);
+  aio::doAssert(pars->keepSites!=NULL,1,AT,"");
   bufstr.l=0;
   int doGenoInner = abs(doGeno);
   for(int s=0;s<pars->numSites;s++) {

--- a/abcCounts.cpp
+++ b/abcCounts.cpp
@@ -5,7 +5,6 @@
 */
 
 #include <htslib/kstring.h>
-#include <cassert>
 #include "analysisFunction.h"
 #include "abc.h"
 #include "abcCounts.h"
@@ -476,7 +475,7 @@ void abcCounts::print(funkyPars *pars){
     countQs(pars->chk,qsDist,pars->keepSites,minQ);
   
   if(doDepth!=0){
-    assert(pars->counts!=NULL);
+	  aio::doAssert(pars->counts!=NULL,1,AT,"");
     for(int s=0;s<pars->numSites;s++) {
       if(pars->keepSites[s]==0)
 	continue; 
@@ -673,7 +672,7 @@ suint **abcCounts::countNucs(const chunkyT *chk,int *keepSites,int mmin,int mmax
 void abcCounts::run(funkyPars *pars){
   if(doCounts==0)
     return;
-  assert(pars->chk!=NULL&&pars->counts==NULL);
+  aio::doAssert(pars->chk!=NULL&&pars->counts==NULL,1,AT,"");
   pars->counts = countNucs(pars->chk,pars->keepSites,setMinDepthInd,setMaxDepthInd);
   if(doebd){
     counts *cnts = new counts;

--- a/abcError.cpp
+++ b/abcError.cpp
@@ -1,6 +1,5 @@
 #include <list>
 #include <cmath>
-#include <cassert>
 #include "bfgs.h"
 #include "analysisFunction.h"
 #include "abcError.h"
@@ -420,7 +419,7 @@ void abcError::clean(funkyPars *pars){
 void abcError::run(funkyPars *pars){
   if(doError==0)
     return;
-  assert(pars->counts!=NULL);
+  aio::doAssert(pars->counts!=NULL,1,AT,"");
     
 
   //  pars->opt->emIter=emIter;

--- a/abcFilter.cpp
+++ b/abcFilter.cpp
@@ -10,7 +10,6 @@ osome if we have reached the last position from the keep list.
 Maybe there are some memleaks. This will have to be fixed later.
 */
 
-#include <cassert>
 #include <sys/stat.h>
 #include "shared.h"
 #include "abc.h"

--- a/abcFreq.cpp
+++ b/abcFreq.cpp
@@ -9,7 +9,6 @@
 
 */
 
-#include <cassert>
 #include <cmath>
 #include <htslib/kstring.h>
 #include <htslib/bgzf.h>
@@ -442,7 +441,7 @@ void abcFreq::print(funkyPars *pars) {
 
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+	  aio::doAssert(major!=4&&minor!=4,1,AT,"");
 	
       for(int i=0;i<3*pars->nInd;i++) {
 	ksprintf(&bufstr, "\t%f",pars->post[s][i]);
@@ -596,7 +595,7 @@ void abcFreq::run(funkyPars *pars) {
     }
   }
   if(doPost) {
-    assert(pars->likes!=NULL);
+	  aio::doAssert(pars->likes!=NULL,1,AT,"");
 
     double **post = new double*[pars->numSites];
     double **like=angsd::get3likes(pars);
@@ -622,7 +621,7 @@ void abcFreq::run(funkyPars *pars) {
 	   fprintf(stderr,"\t-> Problem calling genotypes at: (%s,%d)\n",header->target_name[pars->refId],pars->posi[s]+1);	   
       }
       else if(doPost==4){
-	assert(fl!=NULL);
+		aio::doAssert(fl!=NULL,1,AT,"");
 	//af for this pos: fl->af[pars->posi[s]]
 	//an for this pos: fl->an[pars->posi[s]]
 	//ac for this pos: fl->ac[pars->posi[s]]
@@ -680,7 +679,7 @@ void abcFreq::likeFreq(funkyPars *pars,freqStruct *freq){//method=1: bfgs_known 
     loglike= pars->likes;
   else
     loglike=angsd::get3likesRescale(pars);
-  assert(loglike!=NULL);
+  aio::doAssert(loglike!=NULL,1,AT,"");
 
   if(doSNP)
     freq->lrt = new double[pars->numSites];
@@ -1283,7 +1282,7 @@ double abcFreq::emFrequency(double *loglike,int numInds, int iter,double start,i
       break;
     }
     p=-999;
-    assert(p!=999);
+	aio::doAssert(p!=999,1,AT,"");
     return p;
   }
 

--- a/abcFreq.cpp
+++ b/abcFreq.cpp
@@ -144,7 +144,7 @@ void abcFreq::getOptions(argStruct *arguments){
   underflowprotect=angsd::getArg("-underFlowProtect",underflowprotect,arguments);
 
   minMaf=angsd::getArg("-minMaf",minMaf,arguments);
-  //  assert(minMaf<=1&&minMaf>=0);
+  //  ASSERT(minMaf<=1&&minMaf>=0);
 
   double tmp=-1;
   tmp=angsd::getArg("-SNP_pval",tmp,arguments);

--- a/abcGL.cpp
+++ b/abcGL.cpp
@@ -20,7 +20,6 @@
 */
 
 #include <cmath>
-#include <assert.h>
 #include <htslib/kstring.h>
 #include "analysisFunction.h"
 #include "abc.h"
@@ -294,9 +293,9 @@ abcGL::abcGL(const char *outfiles,argStruct *arguments,int inputtype){
 
 abcGL::~abcGL(){
   if(GL>0&&doGlf==5){
-      assert(outfileSAF!=NULL);
-    assert(outfileSAFIDX!=NULL);
-    assert(outfileSAFPOS!=NULL);
+      aio::doAssert(outfileSAF!=NULL,AT);
+    aio::doAssert(outfileSAFIDX!=NULL,AT);
+    aio::doAssert(outfileSAFPOS!=NULL,AT);
     //  fprintf(stderr,"nnnSites:%d\n",nnnSites);
     if(nnnSites!=0&&tmpChr!=NULL){
       size_t clen = strlen(tmpChr);
@@ -368,11 +367,11 @@ void abcGL::print(funkyPars *pars){
 
 
 void abcGL::run(funkyPars *pars){
-  assert(pars!=NULL);
+  aio::doAssert(pars!=NULL,AT);
   
   if(GL==0)
     return;
-  //assert(pars->chk!=NULL);
+  //aio::doAssert(pars->chk!=NULL);
   double **likes = NULL;
   if(soap.doRecal!=1 || ancestral_lik.doRecal!=1)
     likes = new double*[pars->chk->nSites];
@@ -482,7 +481,7 @@ void abcGL::getLikesFullError10Genotypes(int numSites,int nInd,suint **counts,do
 }
 
 void abcGL::printLike(funkyPars *pars) {
-  assert(pars->likes!=NULL);
+  aio::doAssert(pars->likes!=NULL,AT);
 
   
   if(doGlf==1){
@@ -498,7 +497,7 @@ void abcGL::printLike(funkyPars *pars) {
     bufstr.l = 0; //set tmpbuf beginning to zero
     for(int s=0;s<pars->numSites;s++) {
       lh3struct *lh3 = (lh3struct*) pars->extras[index+2];
-      assert(lh3);
+      aio::doAssert(lh3!=NULL,AT);
       if(pars->keepSites[s]==0||lh3->hasAlloced[s]==0)
 	continue;
       
@@ -512,7 +511,7 @@ void abcGL::printLike(funkyPars *pars) {
 
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+      aio::doAssert(major!=4&&minor!=4,AT);
 
      
       for(int i=0;i<pars->nInd;i++) {
@@ -524,9 +523,9 @@ void abcGL::printLike(funkyPars *pars) {
 	ksprintf(&bufstr, "\t%f",val[0]);
 	ksprintf(&bufstr, "\t%f",val[1]);
 	ksprintf(&bufstr, "\t%f",val[2]);
-	assert(!std::isnan(val[0]));
-	assert(!std::isnan(val[1]));
-	assert(!std::isnan(val[2]));
+	aio::doAssert(!std::isnan(val[0]),AT);
+	aio::doAssert(!std::isnan(val[1]),AT);
+	aio::doAssert(!std::isnan(val[2]),AT);
       }
 
       if(bufstr.l!=0)
@@ -541,7 +540,7 @@ void abcGL::printLike(funkyPars *pars) {
 	continue;
       char major = pars->major[s];
       char minor = pars->minor[s] ;
-      assert(major!=4&&minor!=4);
+      aio::doAssert(major!=4&&minor!=4,AT);
 
       for(int i=0;i<pars->nInd;i++) {
 	double dump[3];
@@ -592,9 +591,9 @@ void abcGL::printLike(funkyPars *pars) {
 void abcGL::changeChr(int refId) {
   //  fprintf(stderr,"Charnge chr:%d\n",refId);
   if(GL>0&&doGlf==5){
-    assert(outfileSAF!=NULL);
-    assert(outfileSAFIDX!=NULL);
-    assert(outfileSAFPOS!=NULL);
+    aio::doAssert(outfileSAF!=NULL,AT);
+    aio::doAssert(outfileSAFIDX!=NULL,AT);
+    aio::doAssert(outfileSAFPOS!=NULL,AT);
     //  fprintf(stderr,"nnnSites:%d\n",nnnSites);
     if(nnnSites!=0&&tmpChr!=NULL){
       size_t clen = strlen(tmpChr);

--- a/abcGetFasta.cpp
+++ b/abcGetFasta.cpp
@@ -9,7 +9,6 @@
   Actually no need to mutex, except for the first chunk. Lets fix it at some point.
 */
 
-#include <cassert>
 
 #include "analysisFunction.h"
 #include "shared.h"
@@ -137,7 +136,7 @@ char *abcGetFasta::loadChr(perFasta *f, char*chrName,int chrId){
 
 char *abcGetFasta::magic(int refId,int *posi,int numSites,perFasta *f){
   pthread_mutex_lock(&f->aMut);
-  assert(refId!=-1);
+  aio::doAssert(refId!=-1,1,AT,"");
   //load new chr if different from last or if nothing has been loaded before
   if(f->curChr==-1||refId!=f->curChr){
     //    fprintf(stderr,"[%s] chaning to chr: %d\n",__FUNCTION__,refId);

--- a/abcHetPlas.cpp
+++ b/abcHetPlas.cpp
@@ -1,6 +1,5 @@
 #include <cmath>
 #include <ctype.h>
-#include <assert.h>
 #include "abc.h"
 #include "analysisFunction.h"
 #include "shared.h"
@@ -116,7 +115,7 @@ double em3(double *x,double **liks,int seqdepth,int maxIter,double tole,int &itr
       break;
       exit(0);
     }
-    assert(newlike>=likev);
+    aio::doAssert(newlike>=likev);
     //fprintf(stderr,"lik=%f newlike=%f\n",likev,newlike);
 
     likev=newlike;
@@ -163,7 +162,7 @@ void abcHetPlas::doNew(funkyPars *pars){
 	//¯	fprintf(stderr,"lik=%f\n",like(par,liks,seqdepth));
 	em3(par,liks,seqdepth,maxIter,1e-6,rs->nItr[s][i],rs->diff[s][i]);
 	int maxBase=angsd::whichMax(par,4);
-	//assert(maxBase!=-1);//<- if vals are equal...
+	//aio::doAssert(maxBase!=-1);//<- if vals are equal...
 	if(maxBase==-1){
 	  fprintf(stderr,"CHECK SITE: %d  par=(%f,%f,%f,%f) seqdepth=%d\n",pars->posi[s]+1,par[0],par[1],par[2],par[3],seqdepth);
 	  pars->keepSites[s] =0;
@@ -204,8 +203,8 @@ void abcHetPlas::run(funkyPars *pars){
     fprintf(stderr,"skipping due to nos sites\n");
     return;
   }
-  assert(pars->numSites>0);
-  assert(pars->chk!=NULL);
+  aio::doAssert(pars->numSites>0);
+  aio::doAssert(pars->chk!=NULL);
   if(doHetPlas){
     //exit(0);
     doNew(pars);

--- a/abcIBS.cpp
+++ b/abcIBS.cpp
@@ -6,7 +6,6 @@
   part of angsd
   NB for cov. maf > 0.001 is hardcoded (don't want the world to explode)
 */
-#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <htslib/kstring.h>
@@ -268,12 +267,12 @@ void abcIBS::printHaplo(funkyPars *pars){
   if(makeMatrix){
     for(int i=0;i<pars->nInd;i++){
       for(int j=0;j<pars->nInd;j++){
-	assert( haplo->ibsMatrix[i*pars->nInd+j] >= 0  || haplo->nonMis[i*pars->nInd+j] >= 0 );
+	aio::doAssert( haplo->ibsMatrix[i*pars->nInd+j] >= 0  || haplo->nonMis[i*pars->nInd+j] >= 0 ,1,AT,"");
 	//	  fprintf(stdout,"negative count %d\t%d\n",haplo->ibsMatrix[i*pars->nInd+j],haplo->nonMis[i*pars->nInd+j]);
 
 	ibsMatrixAll[i*pars->nInd+j] += haplo->ibsMatrix[i*pars->nInd+j];
 	nonMisAll[i*pars->nInd+j] += haplo->nonMis[i*pars->nInd+j];
-	assert(nonMisAll[i*pars->nInd+j] >= 0  || ibsMatrixAll[i*pars->nInd+j] >= 0);
+	aio::doAssert(nonMisAll[i*pars->nInd+j] >= 0  || ibsMatrixAll[i*pars->nInd+j] >= 0,1,AT,"");
       }
     }
   }

--- a/abcMajorMinor.cpp
+++ b/abcMajorMinor.cpp
@@ -28,13 +28,14 @@
 
 
 #include <cmath> //<- for log,exp
-#include <cassert>
 #include <cfloat>
 #include "shared.h"
 #include "analysisFunction.h"
 #include "abc.h"
 #include "abcMajorMinor.h"
 #include "abcFilter.h"
+#include "aio.h"
+
 static int isnaninf(double *d,int l){
   for(int i=0;i<l;i++)
     if(std::isnan(d[i])||std::isinf(d[i]))
@@ -278,7 +279,7 @@ void abcMajorMinor::majorMinorGL(funkyPars *pars,int doMajorMinor){
 	fprintf(stdout,"\t-> Something has gone wrong trying to infer major/minor from GLS at \'%s\' %d will discard site from analysis\n",header->target_name[pars->refId],pars->posi[s]+1);
 	pars->keepSites[s]=0;
       }
-      // assert(choiceMajor!=-1&&choiceMinor!=-1);
+      // aio::doAssert(choiceMajor!=-1&&choiceMinor!=-1);
       for(int i=0;i<pars->nInd;i++){
 	W0=exp(pars->likes[s][i*10+angsd::majorminor[choiceMajor][choiceMajor]])*0.25;
 	W1=exp(pars->likes[s][i*10+angsd::majorminor[choiceMajor][choiceMinor]])*0.5;
@@ -389,7 +390,7 @@ int abcMajorMinor::majorMinorEBD(funkyPars *pars,int doMajorMinor){
 }
 
 void majorMinorCounts(suint **counts,int nFiles,int nSites,char *major,char *minor,int *keepSites,int doMajorMinor,char *ref,char *anc) {
-  assert(counts!=NULL);
+  aio::doAssert(counts!=NULL,1,AT,"");
 
   for(int s=0;s<nSites;s++){
     if(keepSites==0)
@@ -517,7 +518,7 @@ void abcMajorMinor::run(funkyPars *pars){
 	continue;
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+      aio::doAssert(major!=4&&minor!=4,1,AT,"");
       
       lh3->hasAlloced[s]=1;
       lh3->lh3[s] = new double[3*pars->nInd];

--- a/abcMcall.cpp
+++ b/abcMcall.cpp
@@ -1,5 +1,5 @@
-#include <cassert>
 #include "abc.h"
+#include "aio.h"
 #include "analysisFunction.h"
 #include "shared.h"
 #include "abcMcall.h"
@@ -22,7 +22,7 @@ void abcMcall::printArg(FILE *fp){
 }
 
 void offset2allele(int a,int &b,int &c){
-  assert(a>=0&&a<10);
+  aio::doAssert(a>=0&&a<10,1,AT,"");
   if(a==0){//AA
     b=0;
     c=0;
@@ -605,8 +605,8 @@ void abcMcall::run(funkyPars *pars) {
        int b2=refToInt[DAS_BEST[1]];
        //    fprintf(stderr,"offset2allele: which=%d a1=%d a2=%d DAS: b1=%d b2=%d lk: %f nd->l: %d\n",whichmax,a1,a2,b1,b2,gc_llh[i*10+whichmax],pars->chk->nd[s][i]?pars->chk->nd[s][i]->l:0);
        if(b2!=4){
-	 assert(a1==b1||a1==b2);
-	 assert(a2==b1||a2==b2);
+	 aio::doAssert(a1==b1||a1==b2);
+	 aio::doAssert(a2==b1||a2==b2);
        }
        dat->gcdat[s][i] = -1;
        if(pars->chk->nd[s][i]&&pars->chk->nd[s][i]->l>0){

--- a/abcPSMC.cpp
+++ b/abcPSMC.cpp
@@ -2,7 +2,6 @@
   This is a class that dumps psmc file output
 
  */
-#include <assert.h>
 
 #include "analysisFunction.h"
 #include "shared.h"
@@ -19,7 +18,7 @@ void abcPSMC::printArg(FILE *argFile){
 void abcPSMC::algoJoint(double **liks,int nsites,int *keepSites,psmcRes *r,int noTrans) {
   //  fprintf(stderr,"[%s]\n",__FUNCTION__);
   int myCounter =0;
-  assert(liks);
+  ASSERT(liks);
   for(int it=0; it<nsites; it++) {//loop over sites
     if(keepSites[it]==0)
       continue;
@@ -146,9 +145,9 @@ abcPSMC::abcPSMC(const char *outfiles,argStruct *arguments,int inputtype){
 }
 
 void abcPSMC::writeAll(){
-  assert(outfileSAF!=NULL);
-  assert(outfileSAFIDX!=NULL);
-  assert(outfileSAFPOS!=NULL);
+  aio::doAssert(outfileSAF!=NULL);
+  aio::doAssert(outfileSAFIDX!=NULL);
+  aio::doAssert(outfileSAFPOS!=NULL);
   //  fprintf(stderr,"nnnSites:%d\n",nnnSites);
   if(nnnSites!=0&&tmpChr!=NULL){
     size_t clen = strlen(tmpChr);

--- a/abcSaf.cpp
+++ b/abcSaf.cpp
@@ -1,6 +1,5 @@
 #include <cstdio>
 #include <cmath>
-#include <assert.h>
 #include <cfloat>
 #include <htslib/kstring.h>
 #include "abcFreq.h"
@@ -234,7 +233,7 @@ abcSaf::abcSaf(const char *outfiles,argStruct *arguments,int inputtype){
     aio::bgzf_write(outfileSAF,buf,8);
     aio::bgzf_write(outfileSAFPOS,buf,8);
     fwrite(buf,1,8,outfileSAFIDX);
-    assert(bgzf_flush(outfileSAF)==0);assert(bgzf_flush(outfileSAFPOS)==0);
+    aio::doAssert(bgzf_flush(outfileSAF)==0);aio::doAssert(bgzf_flush(outfileSAFPOS)==0);
     offs[0] = bgzf_tell(outfileSAFPOS);
     offs[1] = bgzf_tell(outfileSAF);
     size_t tt = newDim-1;
@@ -500,7 +499,7 @@ int saf_sparsify_and_normalize (double* hj, int& lower, int& upper, const double
 // I would not trust the output of this method until this gets investigated.
 void filipe::algoJoint(double **liks,char *anc,int nsites,int numInds,int underFlowProtect, int *keepSites,realRes *r,int noTrans,int doSaf,char *major,char *minor,double *freq,double *indF,int newDim) {
   //  fprintf(stderr,"liks=%p anc=%p nsites=%d nInd=%d underflowprotect=%d fold=%d keepSites=%p r=%p\n",liks,anc,nsites,numInds,underFlowProtect,fold,keepSites,r);
-  assert(doSaf==2);
+  aio::doAssert(doSaf==2);
   int myCounter =0;
 
   if(anc==NULL||liks==NULL){
@@ -547,7 +546,7 @@ void filipe::algoJoint(double **liks,char *anc,int nsites,int numInds,int underF
 	continue;
     }
 
-    assert(ancB!=-1&&derB!=-1);
+    aio::doAssert(ancB!=-1&&derB!=-1);
     
     double totmax = 0.0;
     
@@ -1461,7 +1460,7 @@ void abcSaf::print(funkyPars *p)
 // NSP 3July2020
 // I left this alone when implementing score-limited algorithm. Not sure if it is even used anymore?
 void abcSaf::algoGeno(int refId,double **liks,char *major,char *minor,int nsites,int numInds,kstring_t *sfsfile,int underFlowProtect,int *posi,int *keepSites,double *pest) {
-  assert(pest!=NULL);
+  aio::doAssert(pest!=NULL);
   //void algGeno(aMap &asso,int numInds,FILE *sfsfile,int underFlowProtect, double *pest) {
   //  fprintf(stderr,"UNDERFLOWPROTECT: %d\n",underFlowProtect);
   double *postp = new double[3*numInds];
@@ -1789,7 +1788,7 @@ void abcSaf::algoGeno(int refId,double **liks,char *major,char *minor,int nsites
       for(int i=0;i<3;i++)
 	res[i] =exp(res[i])/mySum;
       int best = angsd::whichMax(res,3);
-      assert(best!=-1);
+      aio::doAssert(best!=-1);
       //      fprintf(stderr,"best:%d\n",best);
       whichGeno[select] = best;
       whichProb[select] = res[best];
@@ -1821,9 +1820,9 @@ void abcSaf::algoGeno(int refId,double **liks,char *major,char *minor,int nsites
 }
 
 void abcSaf::writeAll(){
-  assert(outfileSAF!=NULL);
-  assert(outfileSAFIDX!=NULL);
-  assert(outfileSAFPOS!=NULL);
+  aio::doAssert(outfileSAF!=NULL);
+  aio::doAssert(outfileSAFIDX!=NULL);
+  aio::doAssert(outfileSAFPOS!=NULL);
   //  fprintf(stderr,"nnnSites:%d\n",nnnSites);
   if(nnnSites!=0&&tmpChr!=NULL){
     size_t clen = strlen(tmpChr);
@@ -1836,7 +1835,7 @@ void abcSaf::writeAll(){
   }//else
    // fprintf(stderr,"enpty chr\n");
   //reset
-  assert(bgzf_flush(outfileSAF)==0);assert(bgzf_flush(outfileSAFPOS)==0);
+  aio::doAssert(bgzf_flush(outfileSAF)==0);aio::doAssert(bgzf_flush(outfileSAFPOS)==0);
   offs[0] = bgzf_tell(outfileSAFPOS);
   offs[1] = bgzf_tell(outfileSAF);
   nnnSites=0;

--- a/abcScounts.cpp
+++ b/abcScounts.cpp
@@ -1,5 +1,4 @@
 #include <ctype.h>
-#include <cassert>
 #include "shared.h"
 #include "analysisFunction.h"
 #include "abcScounts.h"
@@ -134,7 +133,7 @@ void abcScounts::print(funkyPars *pars){
       cnts.C = pars->counts[s][1];
       cnts.G = pars->counts[s][2];
       cnts.T = pars->counts[s][3];
-      assert(sizeof(counts)==bgzf_write(outfile,&cnts,sizeof(counts)*1));
+      aio::doAssert(sizeof(counts)==bgzf_write(outfile,&cnts,sizeof(counts)*1),1,AT,"");
       
     }
   }

--- a/abcWriteBcf.cpp
+++ b/abcWriteBcf.cpp
@@ -2,7 +2,6 @@
   This is a class that dumps BCF output. Its mainly a wrapper around other classes here in angsd. Maybe this should be streamlined abit
 */
 
-#include <assert.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -103,7 +102,7 @@ void print_bcf_header(htsFile *fp,bcf_hdr_t *hdr,argStruct *args,kstring_t &buf,
   bcf_hdr_append(hdr,"##FORMAT=<ID=EBD,Number=4,Type=Float,Description=\"The effective basedepth\">");
   //fprintf(stderr,"samples from sm:%d\n",args->sm->n);
   buf.l =0;
-  assert(args);
+  ASSERT(args);
   ksprintf(&buf, "##angsdVersion=%s",args->version);
   bcf_hdr_append(hdr, buf.s);
   
@@ -128,7 +127,7 @@ void abcWriteBcf::clean(funkyPars *pars){
 }
 
 void abcWriteBcf::print(funkyPars *pars){
-  assert(bcf_hdr_nsamples(hdr)>0);
+  aio::doAssert(bcf_hdr_nsamples(hdr)>0);
   if(doBcf==0)
     return;
  
@@ -172,14 +171,14 @@ void abcWriteBcf::print(funkyPars *pars){
     bcf_update_filter(hdr, rec, &tmpi, 1);
     // .. INFO
     tmpi = pars->keepSites[s];
-    assert(bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1)==0);
+    aio::doAssert(bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1)==0);
     if(mcall){
 
       float *tmp = mcall->QS+5*s;
       //      for(int i=0;i<5;i++)	fprintf(stderr,"qs[%d]: %f\n",i,tmp[i]);
-      assert(bcf_update_info_float(hdr, rec, "QS_angsd", tmp, 5)==0);
+      aio::doAssert(bcf_update_info_float(hdr, rec, "QS_angsd", tmp, 5)==0);
       tmp = mcall->quals+2*s;
-      assert(bcf_update_info_float(hdr, rec, "Quals_angsd", tmp, 2)==0);
+      aio::doAssert(bcf_update_info_float(hdr, rec, "Quals_angsd", tmp, 2)==0);
       if(mcall->isvar[s]>0)
 	rec->qual = tmp[0];
       else
@@ -192,15 +191,15 @@ void abcWriteBcf::print(funkyPars *pars){
       for(int i=0; i<4*pars->nInd; i++)
 	depth += pars->counts[s][i];
       tmpi = depth;
-      assert(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1)==0);
+      aio::doAssert(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1)==0);
     }
     if(freq){
       float tmpf = freq->freq[s];
-      assert(bcf_update_info_float(hdr, rec, "AF", &tmpf, 1)==0);
+      aio::doAssert(bcf_update_info_float(hdr, rec, "AF", &tmpf, 1)==0);
     }
     
     // .. FORMAT
-    // assert(geno);
+    // aio::doAssert(geno);
     //    fprintf(stderr,"bcf_hdr_nsamples(hdr): %d\n",bcf_hdr_nsamples(hdr));
     if(geno&&mcall==NULL){
       int32_t *tmpia = (int*)malloc(bcf_hdr_nsamples(hdr)*2*sizeof(int32_t));
@@ -226,7 +225,7 @@ void abcWriteBcf::print(funkyPars *pars){
       int32_t *tmpia = (int*)malloc(bcf_hdr_nsamples(hdr)*2*sizeof(int32_t));
       for(int i=0; i<pars->nInd;i++){
 	if(mcall->gcdat[s][2*i]==-1)
-	  assert(mcall->gcdat[s][2*i]==mcall->gcdat[s][2*i+1]);
+	  aio::doAssert(mcall->gcdat[s][2*i]==mcall->gcdat[s][2*i+1]);
 
 	if(mcall->gcdat[s][2*i]==-1){
 	  tmpia[2*i+0] = bcf_gt_missing;
@@ -253,7 +252,7 @@ void abcWriteBcf::print(funkyPars *pars){
 
       int major = pars->major[s];
       int minor = pars->minor[s];
-      assert(major!=4&&minor!=4);
+      aio::doAssert(major!=4&&minor!=4);
       for(int i=0;i<bcf_hdr_nsamples(hdr);i++){
 	double val[3];
 	val[0] = pars->likes[s][i*10+angsd::majorminor[major][major]];

--- a/abcWriteFasta.cpp
+++ b/abcWriteFasta.cpp
@@ -1,7 +1,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <htslib/bgzf.h>
-#include <assert.h>
 #include <ctime>
 
 #include "analysisFunction.h"
@@ -236,7 +235,7 @@ void abcWriteFasta::run(funkyPars *pars){
   }
   //Do transitions removal
   if(rmTrans){
-    assert(pars->ref!=NULL);
+    aio::doAssert(pars->ref!=NULL);
     for(int s=0;s<pars->numSites&&pars->posi[s]<header->target_len[pars->refId];s++){
 
       int ob = refToInt[myFasta[pars->posi[s]]];

--- a/abcWritePlink.cpp
+++ b/abcWritePlink.cpp
@@ -2,7 +2,6 @@
   This is a class that dumps plink file output
 
  */
-#include <assert.h>
 
 #include "analysisFunction.h"
 #include "shared.h"
@@ -41,7 +40,7 @@ unsigned char recode(int i){
     return '\x00';
   else if(i==-1)
     return '\x01';
-  assert(0==1);  
+  aio::doAssert(0==1);  
   return 'x';//to remove compile warnings;
 }
 
@@ -167,7 +166,7 @@ void abcWritePlink::getOptions(argStruct *arguments){
     fprintf(stderr,"Must supply -doGeno  to write plink files (consider supplying negative value for suprresing .geno.gz output)\n");
     exit(0);
   }
-  assert(doPlink>=0 && doPlink<=2);
+  aio::doAssert(doPlink>=0 && doPlink<=2);
   if(doPlink==0)
     return;
   

--- a/abcWriteVcf.cpp
+++ b/abcWriteVcf.cpp
@@ -2,7 +2,6 @@
   This is a class that dumps plink file output
 
  */
-#include <assert.h>
 
 #include "analysisFunction.h"
 #include "shared.h"

--- a/aio.cpp
+++ b/aio.cpp
@@ -119,8 +119,7 @@ neverUseGoto:
 
 
 void aio::doAssert(int exp_eval, int exit_code, const char* error_location, const char* exit_text,...){
-	// if( exp_eval || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
-	if( exp_eval ){
+	if( exp_eval || exp_eval==1 || exp_eval==true){
 		return;
 	}else{
 		fprintf(stderr, "\n");
@@ -139,7 +138,7 @@ void aio::doAssert(int exp_eval, int exit_code, const char* error_location, cons
 
 // Function overload to avoid specifying exit code. If not specified exit 1
 void aio::doAssert(int exp_eval, const char* error_location, const char* exit_text,...){
-	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+	if( exp_eval || exp_eval==1 || exp_eval==true){
 		return;
 	}else{
 		fprintf(stderr, "\n");
@@ -156,9 +155,9 @@ void aio::doAssert(int exp_eval, const char* error_location, const char* exit_te
 }
 
 
-// Function overload to avoid specifying exit code. If not specified exit 1
+// Function overload to avoid specifying exit code and exit text. If not specified exit 1
 void aio::doAssert(int exp_eval, const char* error_location){
-	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+	if( exp_eval || exp_eval==1 || exp_eval==true){
 		return;
 	}else{
 		fprintf(stderr, "\n");
@@ -172,7 +171,7 @@ void aio::doAssert(int exp_eval, const char* error_location){
 
 // Function overload to avoid specifying anything, just evaluate and exit 1
 void aio::doAssert(int exp_eval){
-	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+	if( exp_eval || exp_eval==1 || exp_eval==true){
 		return;
 	}else{
 		fprintf(stderr, "\n");
@@ -183,11 +182,3 @@ void aio::doAssert(int exp_eval){
 	}
 }
 
-void aio::assertFailed(const char* error_location, const char* error_expression){
-	fprintf(stderr, "\n");
-	fprintf(stderr, "*******\n");
-	fprintf(stderr, "[ERROR](%s): %s\n",error_location,error_expression);
-	fprintf(stderr, "*******\n");
-	fprintf(stderr, "\n");
-	exit(1);
-}

--- a/aio.cpp
+++ b/aio.cpp
@@ -117,21 +117,77 @@ neverUseGoto:
 	return rlen;
 }
 
-//  Usage: aio::doAssert(something==NULL,1,AT,"");
-void aio::doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...){
-	if(EXIT){
-		va_list args;
-		va_start (args, format);
+
+void aio::doAssert(int exp_eval, int exit_code, const char* error_location, const char* exit_text,...){
+	// if( exp_eval || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+	if( exp_eval ){
+		return;
+	}else{
 		fprintf(stderr, "\n");
 		fprintf(stderr, "*******\n");
+		va_list args;
+		va_start (args, exit_text);
 		fprintf(stderr, "[ERROR](%s)\n",error_location);
-		vfprintf (stderr, format, args);
+		vfprintf (stderr, exit_text, args);
 		va_end (args);
 		fprintf(stderr, "\n");
 		fprintf(stderr, "*******\n");
-		exit(EXIT_CODE);
-	}else{
-		return;
+		exit(exit_code);
 	}
 }
 
+
+// Function overload to avoid specifying exit code. If not specified exit 1
+void aio::doAssert(int exp_eval, const char* error_location, const char* exit_text,...){
+	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+		return;
+	}else{
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		va_list args;
+		va_start (args, exit_text);
+		fprintf(stderr, "[ERROR](%s)\n",error_location);
+		vfprintf (stderr, exit_text, args);
+		va_end (args);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		exit(1);
+	}
+}
+
+
+// Function overload to avoid specifying exit code. If not specified exit 1
+void aio::doAssert(int exp_eval, const char* error_location){
+	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+		return;
+	}else{
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		fprintf(stderr, "[ERROR](%s)\n",error_location);
+		fprintf(stderr, "*******\n");
+		exit(1);
+	}
+}
+
+
+// Function overload to avoid specifying anything, just evaluate and exit 1
+void aio::doAssert(int exp_eval){
+	if( (exp_eval) || exp_eval!=NULL || exp_eval==1 || exp_eval==true){
+		return;
+	}else{
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		fprintf(stderr, "[ERROR]\n");
+		fprintf(stderr, "*******\n");
+		exit(1);
+	}
+}
+
+void aio::assertFailed(const char* error_location, const char* error_expression){
+	fprintf(stderr, "\n");
+	fprintf(stderr, "*******\n");
+	fprintf(stderr, "[ERROR](%s): %s\n",error_location,error_expression);
+	fprintf(stderr, "*******\n");
+	fprintf(stderr, "\n");
+	exit(1);
+}

--- a/aio.cpp
+++ b/aio.cpp
@@ -1,117 +1,137 @@
 #include <cstring>
+#include <stdarg.h>
 #include <sys/stat.h>
 #include "aio.h"
 
 int aio::fexists(const char* str){///@param str Filename given as a string.
-  struct stat buffer ;
-  return (stat(str, &buffer )==0 ); /// @return Function returns 1 if file exists.
+	struct stat buffer ;
+	return (stat(str, &buffer )==0 ); /// @return Function returns 1 if file exists.
 }
 
 size_t aio::fsize(const char* fname){
-  struct stat st ;
-  stat(fname,&st);
-  return st.st_size;
+	struct stat st ;
+	stat(fname,&st);
+	return st.st_size;
 }
 
 std::vector <char *> dumpedFiles;//small hack for getting a nice vector of outputfiles
 FILE *aio::openFile(const char* a,const char* b){
-  if(0)
-    fprintf(stderr,"[%s] %s %s",__FUNCTION__,a,b);
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  //  fprintf(stderr,"\t-> Dumping file: %s\n",c);
-  dumpedFiles.push_back(strdup(c));
-  FILE *fp = NULL;
-  fp = fopen(c,"w");
-  if(fp==NULL){
-    fprintf(stderr,"\t-> Problem opening file: \'%s\' check permissions\n",c);
-    exit(0);
-  }
-  delete [] c;
-  return fp;
+	if(0)
+		fprintf(stderr,"[%s] %s %s",__FUNCTION__,a,b);
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	//  fprintf(stderr,"\t-> Dumping file: %s\n",c);
+	dumpedFiles.push_back(strdup(c));
+	FILE *fp = NULL;
+	fp = fopen(c,"w");
+	if(fp==NULL){
+		fprintf(stderr,"\t-> Problem opening file: \'%s\' check permissions\n",c);
+		exit(0);
+	}
+	delete [] c;
+	return fp;
 }
 
 BGZF *aio::openFileBG(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  BGZF *fp = bgzf_open(c,"w6h");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	BGZF *fp = bgzf_open(c,"w6h");
+	delete [] c;
+	return fp;
 }
 
 htsFile *aio::openFileHts(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  htsFile *fp = hts_open(c,"w");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	htsFile *fp = hts_open(c,"w");
+	delete [] c;
+	return fp;
 }
 
 htsFile *aio::openFileHtsBcf(const char* a,const char* b){
 
-  char *c = new char[strlen(a)+strlen(b)+1];
-  strcpy(c,a);
-  strcat(c,b);
-  dumpedFiles.push_back(strdup(c));
-  htsFile *fp = hts_open(c,"wb");
-  delete [] c;
-  return fp;
+	char *c = new char[strlen(a)+strlen(b)+1];
+	strcpy(c,a);
+	strcat(c,b);
+	dumpedFiles.push_back(strdup(c));
+	htsFile *fp = hts_open(c,"wb");
+	delete [] c;
+	return fp;
 }
 
 FILE *aio::getFILE(const char*fname,const char* mode){
-  int writeFile = 0;
-  for(size_t i=0;i<strlen(mode);i++)
-    if(mode[i]=='w')
-      writeFile = 1;
-  FILE *fp;
-  if(NULL==(fp=fopen(fname,mode))){
-    fprintf(stderr,"\t-> Error opening FILE handle for file:%s exiting\n",fname);
-    exit(0);
-  }
-  return fp;
+	int writeFile = 0;
+	for(size_t i=0;i<strlen(mode);i++)
+		if(mode[i]=='w')
+			writeFile = 1;
+	FILE *fp;
+	if(NULL==(fp=fopen(fname,mode))){
+		fprintf(stderr,"\t-> Error opening FILE handle for file:%s exiting\n",fname);
+		exit(0);
+	}
+	return fp;
 }
 
 //checks that newer is newer than older
 int aio::isNewer(const char *newer,const char *older){
-   if (strstr(older, "ftp://") == older || strstr(older, "http://") == older)
-     return 0;
-  //  fprintf(stderr,"newer:%s older:%s\n",newer,older);
-  // return 0;
-  struct stat one;
-  struct stat two;
-  stat(newer, &one );
-  stat(older, &two );
-  
-  return one.st_mtime>=two.st_mtime;
+	if (strstr(older, "ftp://") == older || strstr(older, "http://") == older)
+		return 0;
+	//  fprintf(stderr,"newer:%s older:%s\n",newer,older);
+	// return 0;
+	struct stat one;
+	struct stat two;
+	stat(newer, &one );
+	stat(older, &two );
+
+	return one.st_mtime>=two.st_mtime;
 }
 
 ssize_t aio::bgzf_write(BGZF *fp, const void *data, size_t length){
-  if(length>0)
-    return ::bgzf_write(fp,data,length);
-  return 0;
+	if(length>0)
+		return ::bgzf_write(fp,data,length);
+	return 0;
 }
 
 
 int aio::tgets(gzFile gz,char**buf,int *l){
-  int rlen = 0;
- neverUseGoto:
-  char *tok = gzgets(gz,*buf+rlen,*l-rlen);
-  if(!tok)
-    return rlen;
-  int tmp = tok?strlen(tok):0;
-  if(tok[tmp-1]!='\n'){
-    rlen += tmp;
-    *l *= 2;
-    *buf = (char*) realloc(*buf,*l);
-    goto neverUseGoto;
-  }
-  rlen += tmp;
-  return rlen;
+	int rlen = 0;
+neverUseGoto:
+	char *tok = gzgets(gz,*buf+rlen,*l-rlen);
+	if(!tok)
+		return rlen;
+	int tmp = tok?strlen(tok):0;
+	if(tok[tmp-1]!='\n'){
+		rlen += tmp;
+		*l *= 2;
+		*buf = (char*) realloc(*buf,*l);
+		goto neverUseGoto;
+	}
+	rlen += tmp;
+	return rlen;
 }
+
+//  Usage: aio::doAssert(something==NULL,1,AT,"");
+void aio::doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...){
+	if(EXIT){
+		va_list args;
+		va_start (args, format);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		fprintf(stderr, "[ERROR](%s)\n",error_location);
+		vfprintf (stderr, format, args);
+		va_end (args);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "*******\n");
+		exit(EXIT_CODE);
+	}else{
+		return;
+	}
+}
+

--- a/aio.h
+++ b/aio.h
@@ -4,12 +4,21 @@
 #include <htslib/hts.h>
 #include <zlib.h>
 
+
+/*
+ * Macro:[AT]
+ * Injects the file and line info as string
+ */
 #define STRINGIFY(x) #x
 #define ASSTR(x) STRINGIFY(x)
 #define AT __FILE__ ":" ASSTR(__LINE__)
 
-#define ASSERT(expr) \
-	if (!(expr)) aio::assertFailed(AT,#expr)
+/*
+ * Macro:[ASSERT]
+ * shortcut to evaluate an expression, works the same way as the C-macro assert
+ */
+#define ASSERT(expr) if (!(expr)) {fprintf(stderr,"\n\n*******\n[ERROR](%s:%d) %s\n*******\n",__FILE__,__LINE__,#expr);exit(1);}
+
 
 //angsd io
 namespace aio{
@@ -45,5 +54,5 @@ namespace aio{
   void doAssert(int exp_eval, const char* error_location, const char* exit_text,...);
   void doAssert(int exp_eval, const char* error_location);
   void doAssert(int exp_eval);
-  void assertFailed(const char* error_location, const char* error_expression);
+
 }

--- a/aio.h
+++ b/aio.h
@@ -8,6 +8,9 @@
 #define ASSTR(x) STRINGIFY(x)
 #define AT __FILE__ ":" ASSTR(__LINE__)
 
+#define ASSERT(expr) \
+	if (!(expr)) aio::assertFailed(AT,#expr)
+
 //angsd io
 namespace aio{
   size_t fsize(const char* fname);
@@ -20,5 +23,27 @@ namespace aio{
   int isNewer(const char *newer,const char *older);
   ssize_t bgzf_write(BGZF *fp, const void *data, size_t length);
   int tgets(gzFile gz,char**buf,int *l);
-  void doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...);
+
+
+
+/* [doAssert] evaluate a statement, works the same way as C macro assert
+ *
+ * @param exp_eval		expression to evaluate, exit if evaluates to false
+ * @param exit_code 	code to exit with if expression evaluates to false
+ * @error_location		specifies where the error is encountered at
+ * 						macro AT (defined in aio.h) can be used to print
+ * 						(which_file.cpp:which_line)
+ * 
+ * @exit_text			exit text to print before exit, use as in fprintf
+ * 						followed by optional arguments
+ *
+ * @use
+ * aio::doAssert(thisStatementShallBeTrue,1,AT,"Fancy error msg with a val %d",my_var);
+ */
+
+  void doAssert(int exp_eval, int exit_code, const char* error_location, const char* exit_text,...);
+  void doAssert(int exp_eval, const char* error_location, const char* exit_text,...);
+  void doAssert(int exp_eval, const char* error_location);
+  void doAssert(int exp_eval);
+  void assertFailed(const char* error_location, const char* error_expression);
 }

--- a/aio.h
+++ b/aio.h
@@ -3,6 +3,11 @@
 #include <htslib/kstring.h>
 #include <htslib/hts.h>
 #include <zlib.h>
+
+#define STRINGIFY(x) #x
+#define ASSTR(x) STRINGIFY(x)
+#define AT __FILE__ ":" ASSTR(__LINE__)
+
 //angsd io
 namespace aio{
   size_t fsize(const char* fname);
@@ -15,4 +20,5 @@ namespace aio{
   int isNewer(const char *newer,const char *older);
   ssize_t bgzf_write(BGZF *fp, const void *data, size_t length);
   int tgets(gzFile gz,char**buf,int *l);
+  void doAssert(int EXIT, int EXIT_CODE, const char* error_location, const char* format,...);
 }

--- a/analysisFunction.cpp
+++ b/analysisFunction.cpp
@@ -4,7 +4,6 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <list>
-#include <assert.h>
 #include <fstream>
 #include "analysisFunction.h"
 #include "aio.h"
@@ -163,7 +162,7 @@ angsd::Matrix<int> angsd::getMatrixInt(const char *name,int lens){
 }
 
 void angsd::deleteMatrixInt(Matrix<int> mat){
-  assert(mat.matrix!=NULL);
+  aio::doAssert(mat.matrix!=NULL);
   for(int i=0;i<mat.x;i++)
     delete [] mat.matrix[i];
   delete[] mat.matrix;
@@ -171,7 +170,7 @@ void angsd::deleteMatrixInt(Matrix<int> mat){
 }
 
 void angsd::deleteMatrix(Matrix<double> mat){
-  assert(mat.matrix!=NULL);
+  aio::doAssert(mat.matrix!=NULL);
   for(int i=0;i<mat.x;i++)
     delete [] mat.matrix[i];
   delete[] mat.matrix;
@@ -330,7 +329,7 @@ angsd::doubleTrouble<double> angsd::getSample(const char *name,int lens, char* w
     
   }
 
-  assert(count==ncols);
+  aio::doAssert(count==ncols);
   
   //which column we are at
   int pheCols = 0;
@@ -395,7 +394,7 @@ angsd::doubleTrouble<double> angsd::getSample(const char *name,int lens, char* w
 	  } else{	  
 	    pheRow.push_back(atof(tok));
 	  }	  
-	  assert(isBinary==0);
+	  aio::doAssert(isBinary==0);
 	  hasPheno = 1;
 	}
 	column++;
@@ -461,7 +460,7 @@ angsd::doubleTrouble<double> angsd::getSample(const char *name,int lens, char* w
 
 void angsd::deleteDoubleTrouble(doubleTrouble<double> dT){
   
-  assert(dT.matrix0!=NULL && dT.matrix1!=NULL);
+  aio::doAssert(dT.matrix0!=NULL && dT.matrix1!=NULL);
   for(int i=0;i<dT.x0;i++)
     delete [] dT.matrix0[i];
   delete[] dT.matrix0;
@@ -1169,7 +1168,7 @@ int ludcmp(double **a, int *indx, double &d,int n)
     if(big==0){
       //fprintf(stderr,"singular matrix in ludcmp");
       return(1);
-	//    assert(big!=0) ;
+	//    ASSERT(big!=0) ;
 
     }
     vv[i]=1/big;

--- a/ancestral_likes.cpp
+++ b/ancestral_likes.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cmath>
 #include <cstdlib>   /* atoi */
 #include <cstring>
@@ -18,6 +17,7 @@
 #include "ancestral_likes.h"
 #include "analysisFunction.h"
 
+#include "aio.h"
 
 extern int refToInt[256];
 const int PRIMES = 3;
@@ -340,9 +340,9 @@ void anc_likes::gen_counts(const chunkyT *chk, count_mat *count_mat_sample,
 }
 
 void anc_likes::run(chunkyT *chk, double **lk, char *refs, char *ancs, int *keepSites, int trim){
-  assert(chk!=NULL);
+  aio::doAssert(chk!=NULL,1,AT,"");
   if(doRecal==1){
-    assert(myMuts!=NULL);
+    aio::doAssert(myMuts!=NULL,1,AT,"");
 
     if(refs==NULL){
       fprintf(stderr,"\t-> Must supply -ref (reference) for ancestral matrix generation\n");

--- a/angsd.cpp
+++ b/angsd.cpp
@@ -221,8 +221,8 @@ int main(int argc, char** argv){
    parseArgStruct(args);
    
    //Below is main loop which will run until nomore data
-   aio::doAssert(args->hd==NULL,1,AT,"");
-   aio::doAssert(args->revMap==NULL,1,AT,"");
+   aio::doAssert(args->hd!=NULL,AT);
+   aio::doAssert(args->revMap!=NULL,AT);
 
    extern int cigstat;
    if(cigstat)

--- a/angsd.cpp
+++ b/angsd.cpp
@@ -9,7 +9,6 @@
 */
 
 #include "version.h"
-#include <cassert>
 #include <iostream>//for printing time
 #include <cstring> //for cstring functions
 #include <cstdlib> //for exit()
@@ -20,6 +19,7 @@
 #include "shared.h"
 #include "argStruct.h"
 #include "multiReader.h"
+#include "aio.h"
 
 
 extern std::vector <char *> dumpedFiles;
@@ -221,8 +221,8 @@ int main(int argc, char** argv){
    parseArgStruct(args);
    
    //Below is main loop which will run until nomore data
-   assert(args->hd);
-   assert(args->revMap);
+   aio::doAssert(args->hd==NULL,1,AT,"");
+   aio::doAssert(args->revMap==NULL,1,AT,"");
 
    extern int cigstat;
    if(cigstat)

--- a/argStruct.cpp
+++ b/argStruct.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <libgen.h>//for checking if output dir exists 'dirname'
 #include <fstream>
 #include "version.h"
@@ -191,7 +190,7 @@ argStruct *setArgStruct(int argc,char **argv) {
   arguments->nReads = 50;
   arguments->sm=NULL;
   arguments->sm=bam_smpl_init();
-  assert(arguments->sm);
+  aio::doAssert(arguments->sm==NULL,1,AT,"");
  
   arguments->usedArgs= new int[argc+1];//well here we allocate one more than needed, this is only used in the ./angsd -beagle version
   for(int i=0;i<argc;i++)
@@ -305,7 +304,7 @@ char* angsd::getArg(const char* argName, const char* type,argStruct *arguments){
     }
     argPos++;
   }
-  //assert(0==1);
+  //aio::doAssert(0==1);
   //  fprintf(stderr,"post %p\n",type);
   return NULL;
   

--- a/argStruct.cpp
+++ b/argStruct.cpp
@@ -190,7 +190,7 @@ argStruct *setArgStruct(int argc,char **argv) {
   arguments->nReads = 50;
   arguments->sm=NULL;
   arguments->sm=bam_smpl_init();
-  aio::doAssert(arguments->sm==NULL,1,AT,"");
+  ASSERT(arguments->sm);
  
   arguments->usedArgs= new int[argc+1];//well here we allocate one more than needed, this is only used in the ./angsd -beagle version
   for(int i=0;i<argc;i++)
@@ -304,7 +304,7 @@ char* angsd::getArg(const char* argName, const char* type,argStruct *arguments){
     }
     argPos++;
   }
-  //aio::doAssert(0==1);
+  //ASSERT(0==1);
   //  fprintf(stderr,"post %p\n",type);
   return NULL;
   

--- a/bam_likes.cpp
+++ b/bam_likes.cpp
@@ -9,9 +9,10 @@
 #include <stdint.h>
 #include <cstdlib>
 #include <cmath>
-#include <cassert>
 #include <ctype.h>
 #include "mUpPile.h"
+
+#include "aio.h"
 
 extern int refToInt[256];
 #define ERR_DEP 0.83f
@@ -290,7 +291,7 @@ void call_bam(chunkyT *chk,double **lk,int trim,int *keepSites){
       bam_likes_destroy();
     return;
   }
-  assert(mod!=NULL);
+  aio::doAssert(mod!=NULL,1,AT,"");
   for(int s=0;s<chk->nSites;s++){
     lk[s] = new double[10*chk->nSamples];
     if(keepSites[s]==0)

--- a/bammer_main.cpp
+++ b/bammer_main.cpp
@@ -195,7 +195,7 @@ bufReader initBufReader2(const char*fname,int doCheck,char *fai_fname,bam_sample
 	    fprintf(stderr,"\t-> [READGROUP info] Problems adding readgroup: %s for lib: %s\n",rgs_to_add[i],it2->first);
 	  else{
 	    int tmp;
-	    assert(khash_str2int_get(rghash,rgs_to_add[i],&tmp)==0);
+	    aio::doAssert(khash_str2int_get(rghash,rgs_to_add[i],&tmp)==0,1,AT,"");
 	    fprintf(stderr,"\t-> [READGROUP info] Added readgroup %s for lib: %s (check: %s) -> %d\n",rgs_to_add[i],it2->first,it->first,tmp);
 	    if(tmp>254){
 	      fprintf(stderr,"\t-> Readgroup representation is only valid for fewer than 255 different readgroups\n");

--- a/beagleReader.cpp
+++ b/beagleReader.cpp
@@ -1,5 +1,4 @@
 
-#include <cassert>
 #include "analysisFunction.h"
 #include "beagleReader.h"
 #include "aio.h"
@@ -50,7 +49,7 @@ beagle_reader::beagle_reader(gzFile gz_a,const aMap *revMap_a,int intName_a,int 
 void parsepost(char *buffer,double *post,int nInd,const char *delims){
 	for(int i=0;i<nInd*3;i++){
 		char *tsk = strtok_r(NULL,delims,&buffer);
-		assert(tsk!=NULL);
+		aio::doAssert(tsk!=NULL,1,AT,"");
 		post[i] = atof(tsk);
 	}
 }

--- a/bgenReader.h
+++ b/bgenReader.h
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include <cstring>
-#include <cassert>
 
+#include "aio.h"
 #include "argStruct.h"
 #include "analysisFunction.h"
 #include "shared.h"
@@ -61,11 +61,11 @@ public:
   bgenReader(char *fname, const aMap *revMap_a,  int intName_a,int &nInd_a){
 
     FILE *fp=fopen(fname,"rb");
-    assert(fp!=NULL);
+    aio::doAssert(fp!=NULL,1,AT,"");
 
     unsigned offset;
     //unsigned is 4 bytes
-    assert(fread(&offset,sizeof(unsigned),1,fp)==1);
+    aio::doAssert(fread(&offset,sizeof(unsigned),1,fp)==1,1,AT,"");
     
     //read header function
     hd = parseheader(fp);

--- a/chisquare.cpp
+++ b/chisquare.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <limits>
 #include <cstdio>
-#include <cassert>
 #include "chisquare.h"
+#include "aio.h"
 
 using namespace chisq;
 /*
@@ -190,7 +190,7 @@ int main(int argc, char **argv){
   double df;
   std::cout << "Type degrees of freedom"<<std::endl;
   std::cin >> df;
-  assert(df>0);
+  aio::doAssert(df>0,1,AT,"");
   int type =0;
   
   std::cout << "Type 1-3.\n\t1: density (R::dchisq)\n\t2: cdf (R::pchisq)\n\t3: invcdf (R::qchisq)"<<std::endl;

--- a/cigstat.cpp
+++ b/cigstat.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <htslib/hts.h>
@@ -55,7 +54,7 @@ int cum =0;
       int opCode = cigs[i]&BAM_CIGAR_MASK; //what to do
       int opLen = cigs[i]>>BAM_CIGAR_SHIFT; //length of what to do
 for(int s=0;s<opLen;s++){
-  assert(s+cum<1024);
+  aio::doAssert(s+cum<1024,1,AT,"");
 cig_counts[opCode][s+cum]++;
 }
 cum += opLen;
@@ -79,7 +78,7 @@ int cigstat_close(){
       ksprintf(ks,"\t%lu",cig_counts[ncig][p]);
   }
   ksprintf(ks,"\n");
-  assert(ks->l==bgzf_write(bg,ks->s,ks->l));
+  aio::doAssert(ks->l==bgzf_write(bg,ks->s,ks->l),1,AT,"");
   bgzf_close(bg);
   return 0;
 }

--- a/from_samtools.c
+++ b/from_samtools.c
@@ -1,6 +1,5 @@
 #include "from_samtools.h"
 #include <stdio.h>
-#include <assert.h>
 /*
   This file contains modified versions from SAMtools (1.5-1-g27b628e (using htslib 1.5-2-g2739558))
   thorfinn@binf.ku.dk 7aug 2017 cambridge
@@ -51,7 +50,7 @@ void* add_read_groups_file(char *fn)
 	fprintf(stderr,"\t-> [READGROUP info] Problems adding readgroup: %s\n",d);
       else{
 	int tmp;
-	assert(khash_str2int_get(retval,d,&tmp)==0);
+	if(khash_str2int_get(retval,d,&tmp)!=0) exit(1);
 	fprintf(stderr,"\t-> [READGROUP info] Added readgroup %s to id:%d\n",d,tmp);
 	if(tmp>254){
 	  fprintf(stderr,"\t-> Readgroup representation is only valid for fewer than 255 different readgroups\n");

--- a/glfReader.cpp
+++ b/glfReader.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "glfReader.h"
 #include <cfloat>
 

--- a/glfReader_text.cpp
+++ b/glfReader_text.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "analysisFunction.h"
 #include "glfReader_text.h"
 #include "aio.h"
@@ -21,7 +20,7 @@ glfReader_text::glfReader_text(int nInd_a,gzFile gz_a,const aMap *revMap_a){
 void parselikes10(char *buffer,double *likes,int nInd,const char *delims){
   for(int i=0;i<nInd*10;i++){
     char *tsk = strtok_r(NULL,delims,&buffer);
-    assert(tsk!=NULL);
+    aio::doAssert(tsk!=NULL,1,AT,"");
     likes[i] = atof(tsk);
   }
   

--- a/mUpPile.cpp
+++ b/mUpPile.cpp
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <ctype.h>
 #include <pthread.h>
-#include <cassert>
 #include <htslib/hts.h>
 #include <htslib/khash_str2int.h>
 #include "mUpPile.h"
@@ -64,7 +63,7 @@ typedef struct{
 
 template<typename T>
 T getmax(const T *ary,size_t len){
-  assert(len>0&&ary!=NULL);
+  aio::doAssert(len>0&&ary!=NULL,1,AT,"");
       
   T high = ary[0];
   for(size_t i=1;i<len;i++){
@@ -600,7 +599,7 @@ nodePool mkNodes_one_sampleb(readPool *sgl,nodePool *np,abcGetFasta *gf) {
     np->nds = new node[np->m];
   }
   np->l=0;
-  assert(regionLen-lastSecureIndex+4<=np->m);
+  aio::doAssert(regionLen-lastSecureIndex+4<=np->m,1,AT,"");
   for(int i=lastSecureIndex;i<regionLen;i++)
     np->nds[np->l++] = nds[i];
 
@@ -651,7 +650,7 @@ nodePoolT mkNodes_one_sampleTb(readPool *sgl,nodePoolT *np,int refID) {
     if(rghash!=NULL){
       uint8_t *rg = bam_aux_get(rd, "RG");
       if(rg)
-	assert(khash_str2int_get(rghash, (const char*)(rg+1), &thisrg)==0);
+	aio::doAssert(khash_str2int_get(rghash, (const char*)(rg+1), &thisrg)==0,1,AT,"");
     }
     
     if(rd->core.tid!=refID){
@@ -832,7 +831,7 @@ nodePoolT mkNodes_one_sampleTb(readPool *sgl,nodePoolT *np,int refID) {
     kroundup32(np->m);
     np->nds =(tNode**) realloc(np->nds,np->m*sizeof(tNode*));
   }
-  assert(regionLen-lastSecureIndex+4<=np->m);
+  aio::doAssert(regionLen-lastSecureIndex+4<=np->m,1,AT,"");
   //  fprintf(stderr,"np->m:%d\n",np->m)
   np->l=0;
   for(int i=lastSecureIndex;i<regionLen;i++)
@@ -962,7 +961,7 @@ chunkyT *mergeAllNodes_new(nodePoolT *dn,int nFiles) {
   get_span_all_samplesT(dn,nFiles,first,last);
 
   int rlen = last-first+1;
-  assert(rlen>=0);
+  aio::doAssert(rlen>=0,1,AT,"");
   if(rlen>BUG_THRES)
     return slow_mergeAllNodes_new(dn,nFiles);
 
@@ -1073,8 +1072,8 @@ chunky *slow_mergeAllNodes_old(nodePool *dn,int nFiles){
 chunky *mergeAllNodes_old(nodePool *dn,int nFiles) {
   int first,last;
   get_span_all_samples(dn,nFiles,first,last);
-  assert(first!=-1);
-  assert(last!=-1);
+  aio::doAssert(first!=-1,1,AT,"");
+  aio::doAssert(last!=-1,1,AT,"");
   int rlen = last-first+1; 
 
   if(rlen>BUG_THRES) 
@@ -1103,7 +1102,7 @@ chunky *mergeAllNodes_old(nodePool *dn,int nFiles) {
     for( i=0;((i<sm.l)&&(sm.nds[i].refPos <= std::min(sm.last,last) ));i++) {
       
       int posi = sm.nds[i].refPos-offs;
-      assert(posi>=0);
+      aio::doAssert(posi>=0,1,AT,"");
       if(depth[posi]==0){
 	super[posi] = new node[nFiles];
 	for(int ii=0;ii<nFiles;ii++){
@@ -1173,7 +1172,7 @@ int getSglStop5(readPool *sglp,int nFiles,int pickStop) {
       for(int i=0;i<nFiles;i++)
 	if(sglp[i].l>0&&(getmax(sglp[i].first,sglp[i].l)<lowestStart))
 	  lowestStart = getmax(sglp[i].first,sglp[i].l);
-      assert(lowestStart!=pickStop);
+      aio::doAssert(lowestStart!=pickStop,1,AT,"");
     }
 
   lowestStart--;
@@ -1218,7 +1217,7 @@ void getMaxMax2(readPool *sglp,int nFiles,nodePool *nps){
       if(nps[i].last>last_bp_in_chr)
 	last_bp_in_chr = nps[i].last;
     }
-    //  assert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
+    //  aio::doAssert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
     for(int i=0;i<nFiles;i++){
       sglp[i].lowestStart = last_bp_in_chr;
       sglp[i].readIDstop=sglp[i].l;
@@ -1243,7 +1242,7 @@ void getMaxMax2(readPool *sglp,int nFiles,nodePoolT *nps){
     if(nps[i].last>last_bp_in_chr)
       last_bp_in_chr = nps[i].last;
   }
-  //  assert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
+  //  aio::doAssert(last_bp_in_chr!=-1); This assertion should not be active, since it might be true if we don't have data for a whole chromosomes
   for(int i=0;i<nFiles;i++){
     sglp[i].lowestStart = last_bp_in_chr;
     sglp[i].readIDstop=sglp[i].l;
@@ -1369,7 +1368,7 @@ void destroy_tnode_pool(){
 //Most likely this can be written more beautifull by using templated types. But to lazy now.
 int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector<regs> &regions,abcGetFasta *gf) {
   
-  assert(nLines&&nFiles);
+  aio::doAssert(nLines&&nFiles,1,AT,"");
   fprintf(stderr,"\t-> Parsing %d number of samples \n",nFiles);
   fflush(stderr);
   if(show!=1)
@@ -1464,7 +1463,7 @@ int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector
 
     if(theRef==rd[0].hdr->n_targets)
       break;
-    assert(theRef>=0 && theRef<rd[0].hdr->n_targets);//ref should be inrange [0,#nref in header]
+    aio::doAssert(theRef>=0 && theRef<rd[0].hdr->n_targets,1,AT,"");//ref should be inrange [0,#nref in header]
 
     //load fasta for this ref if needed
     void waiter(int);
@@ -1599,7 +1598,7 @@ int uppile(int show,int nThreads,bufReader *rd,int nLines,int nFiles,std::vector
       if(show){
 	//merge the perFile upnodes.FIXME for large regions (with gaps) this will allocate to much...
 	chunky *chk =mergeAllNodes_old(dn,nFiles);
-	assert(chk->refPos[0]<=regStop);
+	aio::doAssert(chk->refPos[0]<=regStop,1,AT,"");
 	
 	chk->regStart = regStart;
 	chk->regStop = regStop;

--- a/makeReadPool.cpp
+++ b/makeReadPool.cpp
@@ -1,4 +1,5 @@
 #include "makeReadPool.h"
+#include "aio.h"
 #define bam_dup(b) bam_copy1(bam_init1(), (b))
 readPool makePoolb(int l){
   readPool ret;
@@ -38,7 +39,7 @@ void realloc(readPool *ret,int l){
 void read_reads_usingStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int refToRead,hts_itr_t *itr,int stop,int &rdObjEof,int &rdObjRegionDone,bam_hdr_t *hdr) {
 
   //if should never be in this function if we shouldnt read from the file.
-  assert(rdObjRegionDone!=1 &&rdObjEof!=1 );
+  aio::doAssert(rdObjRegionDone!=1 &&rdObjEof!=1 ,1,AT,"");
   
   if((nReads+ret.l)>ret.m)
     realloc(&ret,nReads+ret.l);
@@ -132,7 +133,7 @@ void read_reads_usingStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int re
 void read_reads(htsFile *fp,int nReads,int &isEof,readPool &ret,int refToRead,hts_itr_t *itr,int stop,int &rdObjEof,int &rdObjRegionDone,bam_hdr_t *hdr) {
   // fprintf(stderr,"stop:%d nreads:%d reftoread:%d ret.m:%d ret.l:%d\n",stop,nReads,refToRead,ret.m,ret.l);
   //if should never be in this function if we shouldnt read from the file.
-  assert(rdObjRegionDone!=1 &&rdObjEof!=1 );
+  aio::doAssert(rdObjRegionDone!=1 &&rdObjEof!=1 ,1,AT,"");
   
 
   /*
@@ -192,7 +193,7 @@ void read_reads_noStop(htsFile *fp,int nReads,int &isEof,readPool &ret,int refTo
 #if 0
   fprintf(stderr,"\t->[%s] buffRefid=%d\trefToRead=%d\n",__FUNCTION__,ret.bufferedRead.refID,refToRead);
 #endif
-  assert(rdObjEof==0 && ret.bufferedRead ==NULL);
+  aio::doAssert(rdObjEof==0 && ret.bufferedRead ==NULL,1,AT,"");
  
   if((nReads+ret.l)>ret.m)
     realloc(&ret,nReads+ret.l);

--- a/makeReadPool.h
+++ b/makeReadPool.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <cstdlib>
 #include <htslib/hts.h>
 #include <htslib/sam.h>

--- a/misc/contamination.cpp
+++ b/misc/contamination.cpp
@@ -18,9 +18,7 @@
 #include "../fet.c"
 #define LENS 4096
 
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 typedef struct{
   char allele1;

--- a/misc/contamination.cpp
+++ b/misc/contamination.cpp
@@ -11,13 +11,16 @@
 #include <ctype.h>
 #include <vector>
 #include <map>
-#include <cassert>
 #include <ctype.h>
 #include <pthread.h>
 #include "kmath.h"
 
 #include "../fet.c"
 #define LENS 4096
+
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 typedef struct{
   char allele1;
@@ -35,7 +38,7 @@ double sd(double *a,int l){
     ts += a[i];
 
   double u = ts/(1.0*l);
-  // assert(u!=0);
+  // ASSERT(u!=0);
   ts =0;
   for(int i=0;i<l;i++)
     ts += (a[i]-u)*(a[i]-u);
@@ -189,7 +192,7 @@ double jackMom(allPars *ap,int len){
   len=ap->len;
   if(len>0)
     len=std::min(ap->len,len);
-  assert(len>-1);
+  ASSERT(len>-1);
   int *seqDepth=ap->seqDepth;
   int *nonMajor=ap->nonMajor;
   double *freq =ap->freq;
@@ -219,7 +222,7 @@ void *slave(void *ptr){
   for(int i=tp->from;i<tp->to;i++){
     tp->skip=i;
     tp->val[i] = kmin_brent(myfun,1e-6,0.5,tp,1e-6,&tp->thetas[i]);
-    assert(tp->thetas[i]!=1e-6);
+    ASSERT(tp->thetas[i]!=1e-6);
   }
   pthread_exit(0);
 }
@@ -232,7 +235,7 @@ double jackML(allPars *ap,int nthreads,char *fname,int nJack) {
     nJack = ap->len;
   else
     nJack = std::min(ap->len,nJack);
-  assert(nJack>0);
+  ASSERT(nJack>0);
   double *thetas =new double[nJack];
   double *val = new double[nJack];
   if(nthreads>1){
@@ -597,7 +600,7 @@ dat count(aMap &myMap,std::vector<int> &ipos,std::vector<int*> &cnt){
 	  exit(0);
 	}
 	aMap::iterator it2=d.myMap.find(ipos[i]);
-	assert(it2==d.myMap.end());
+	ASSERT(it2==d.myMap.end());
 	d.myMap[it->first] = it->second;
 
       }
@@ -717,7 +720,7 @@ aMap readhap( char *fname,int minDist,double minMaf,int startPos,int stopPos,int
   //  fprintf(stderr,"[%s] We have read: %zu sites from hapfile (after filtering for start/stop pos):%s\n",__FUNCTION__,myMap.size(),fname);
   //fprintf(stderr,"[%s] will remove snp sites to close:\n",__FUNCTION__);
 
-  assert(myMap.size()>0);
+  ASSERT(myMap.size()>0);
   int *vec = new int[myMap.size() -1];
   aMap::iterator it = myMap.begin();
   for(int i=0;i<myMap.size()-1;i++){

--- a/misc/contamination2.cpp
+++ b/misc/contamination2.cpp
@@ -11,13 +11,15 @@
 #include <ctype.h>
 #include <vector>
 #include <map>
-#include <cassert>
 #include <ctype.h>
 #include <pthread.h>
 #include "kmath.h"
 
 #include "../fet.c"
 #define LENS 4096
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 typedef struct{
   char allele1;
@@ -35,7 +37,7 @@ double sd(double *a,int l){
     ts += a[i];
 
   double u = ts/(1.0*l);
-  assert(u!=0);
+  ASSERT(u!=0);
   ts =0;
   for(int i=0;i<l;i++)
     ts += (a[i]-u)*(a[i]-u);
@@ -189,7 +191,7 @@ double jackMom(allPars *ap,int len){
   len=ap->len;
   if(len>0)
     len=std::min(ap->len,len);
-  assert(len>-1);
+  ASSERT(len>-1);
   int *seqDepth=ap->seqDepth;
   int *nonMajor=ap->nonMajor;
   double *freq =ap->freq;
@@ -219,7 +221,7 @@ void *slave(void *ptr){
   for(int i=tp->from;i<tp->to;i++){
     tp->skip=i;
     tp->val[i] = kmin_brent(myfun,1e-6,0.5,tp,1e-6,&tp->thetas[i]);
-    assert(tp->thetas[i]!=1e-6);
+    ASSERT(tp->thetas[i]!=1e-6);
   }
   pthread_exit(0);
 }
@@ -232,7 +234,7 @@ double jackML(allPars *ap,int nthreads,char *fname,int nJack) {
     nJack = ap->len;
   else
     nJack = std::min(ap->len,nJack);
-  assert(nJack>0);
+  ASSERT(nJack>0);
   double *thetas =new double[nJack];
   double *val = new double[nJack];
   if(nthreads>1){
@@ -587,7 +589,7 @@ dat count(aMap &myMap,std::vector<int> &ipos,std::vector<int*> &cnt){
 	  exit(0);
 	}
 	aMap::iterator it2=d.myMap.find(ipos[i]);
-	assert(it2==d.myMap.end());
+	ASSERT(it2==d.myMap.end());
 	d.myMap[it->first] = it->second;
 
       }
@@ -707,7 +709,7 @@ aMap readhap( char *fname,int minDist,double minMaf,int startPos,int stopPos,int
   //  fprintf(stderr,"[%s] We have read: %zu sites from hapfile (after filtering for start/stop pos):%s\n",__FUNCTION__,myMap.size(),fname);
   //fprintf(stderr,"[%s] will remove snp sites to close:\n",__FUNCTION__);
 
-  assert(myMap.size()>0);
+  ASSERT(myMap.size()>0);
   int *vec = new int[myMap.size() -1];
   aMap::iterator it = myMap.begin();
   for(int i=0;i<myMap.size()-1;i++){

--- a/misc/contamination2.cpp
+++ b/misc/contamination2.cpp
@@ -18,8 +18,7 @@
 #include "../fet.c"
 #define LENS 4096
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 typedef struct{
   char allele1;

--- a/misc/exampleSafv3.c
+++ b/misc/exampleSafv3.c
@@ -21,7 +21,6 @@ cat small.txt|./a.out
 #include <zlib.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 
 #define NMAX 96 
 
@@ -51,7 +50,7 @@ int main(){
     }
     if(nbin==-1)
       nbin=at;
-    assert(at==nbin);
+    if(at!=nbin) exit(1);
     bgzf_write(saf,data,sizeof(float)*nbin);
     nsites++;
   }

--- a/misc/fpsmc.cpp
+++ b/misc/fpsmc.cpp
@@ -1,5 +1,4 @@
 #include <vector>
-#include <cassert>
 #include <cmath>
 #include "psmcreader.h"
 #include "main_psmc.h"

--- a/misc/fstreader.cpp
+++ b/misc/fstreader.cpp
@@ -3,6 +3,11 @@
 #include "fstreader.h"
 
 
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
+
 int fstversion(const char *fname){
   gzFile gz=Z_NULL;
   gz = gzopen(fname,"r");
@@ -69,25 +74,25 @@ perfst * perfst_init(char *fname){
     exit(0);
   }
   char buf[8];
-  assert(fread(buf,1,8,fp)==8);
+  ASSERT(fread(buf,1,8,fp)==8);
   ret->version=fstversion(fname);
   //read names
   size_t nit=0;
-  assert(fread(&nit,sizeof(size_t),1,fp)==1);
+  ASSERT(fread(&nit,sizeof(size_t),1,fp)==1);
   //fprintf(stderr,"nit:%lu\n",nit);
   for(int i=0;i<nit;i++){
     size_t clen;
-    assert(fread(&clen,sizeof(size_t),1,fp)==1);
+    ASSERT(fread(&clen,sizeof(size_t),1,fp)==1);
     //fprintf(stderr,"clen:%lu\n",clen);
     char *nam =(char*) calloc(clen+1,1);
-    assert(fread(nam,sizeof(char),clen,fp)==clen);
+    ASSERT(fread(nam,sizeof(char),clen,fp)==clen);
     ret->names.push_back(nam);
   }
 #if 1  
   while(fread(&clen,sizeof(size_t),1,fp)){
     char *chr = (char*)calloc(clen+1,1);
     unsigned a =(unsigned) fread(chr,1,clen,fp);
-    assert(clen==a);    
+    ASSERT(clen==a);    
     dat d;
     if(1!=fread(&d.nSites,sizeof(size_t),1,fp)){
       fprintf(stderr,"[%s.%s():%d] Problem reading data: %s \n",__FILE__,__FUNCTION__,__LINE__,fname);

--- a/misc/fstreader.cpp
+++ b/misc/fstreader.cpp
@@ -2,10 +2,8 @@
 #include "safreader.h"
 #include "fstreader.h"
 
+#include "misc.h"
 
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 
 int fstversion(const char *fname){

--- a/misc/fstreader.h
+++ b/misc/fstreader.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstring>
 #include <cstdlib>
-#include <cassert>
 #include <map>
 #include <vector>
 #include <htslib/bgzf.h>

--- a/misc/hmm_psmc.cpp
+++ b/misc/hmm_psmc.cpp
@@ -1,5 +1,4 @@
 #include <vector>
-#include <cassert>
 #include <cmath>
 #include "psmcreader.h"
 #include "main_psmc.h"

--- a/misc/keep.hpp
+++ b/misc/keep.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <cassert>
 #include <cstring>
 
 template <typename T>
@@ -42,7 +41,7 @@ void realloc(keep<T> *k,size_t newlen){
   //  fprintf(stderr,"[%s] k:%p k->m:%lu newlen:%lu\n",__FUNCTION__,k,k->m,newlen);
   kroundup32(newlen);
   k->d = (T*) realloc(k->d,sizeof(T)*newlen);
-  assert(k->d!=NULL);
+  if(k->d==NULL) exit(1);
   memset(k->d+k->m,0,(newlen-k->m)*sizeof(T));
   k->m=newlen;
   //fprintf(stderr,"[%s] k:%p k->m:%lu newlen:%lu\n",__FUNCTION__,k,k->m,newlen);

--- a/misc/main_psmc.cpp
+++ b/misc/main_psmc.cpp
@@ -6,10 +6,7 @@
 // parse a pattern like "4+5*3+4"
 // the returned array holds which parameters are linked together
 // number of parameters and number of free parameters will be also returned
-
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 int *psmc_parse_pattern(const char *pattern, int *n_free, int *n_pars)
 {

--- a/misc/main_psmc.cpp
+++ b/misc/main_psmc.cpp
@@ -7,6 +7,10 @@
 // the returned array holds which parameters are linked together
 // number of parameters and number of free parameters will be also returned
 
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
 int *psmc_parse_pattern(const char *pattern, int *n_free, int *n_pars)
 {
   fprintf(stderr,"parsing pattern :\"%s\"\n",pattern);
@@ -16,14 +20,14 @@ int *psmc_parse_pattern(const char *pattern, int *n_free, int *n_pars)
 	p = q = tmp = strdup(pattern);
 	k = 1;
 	while (1) {
-		assert(isdigit(*p) || *p == '*' || *p == '+' || *p == '\0'); // allowed characters
+		ASSERT(isdigit(*p) || *p == '*' || *p == '+' || *p == '\0'); // allowed characters
 		if (*p == '+' || *p == '\0') {
 			int is_end = (*p == 0)? 1 : 0;
 			*p++ = '\0';
 			l = atoi(q); q = p;
 			for (i = 0; i < k; ++i) {
 				stack[top++] = l;
-				assert(top <= 0xff);
+				ASSERT(top <= 0xff);
 			}
 			k = 1;
 			if (is_end) break;
@@ -55,7 +59,7 @@ void setpars( char *fname,psmc_par *pp) {
   }
   char *buf = new char[fsize(fname)+10];
   memset(buf,0,fsize(fname)+10);
-  assert(fsize(fname)==fread(buf,sizeof(char),fsize(fname),fp));
+  ASSERT(fsize(fname)==fread(buf,sizeof(char),fsize(fname),fp));
   fclose(fp);
   char *slashslash[100];
   
@@ -105,14 +109,14 @@ void setpars( char *fname,psmc_par *pp) {
   pp->pattern=strdup(tok);
 
   pp->par_map= psmc_parse_pattern(pp->pattern,&pp->n_free,&pp->n);
-  assert(RS.size()-1==pp->n);
+  ASSERT(RS.size()-1==pp->n);
   pp->params = new double[RS.size()];
   pp->times = new double[RS.size()];
 
   for(int i=0;i<RS.size();i++){
     int val;
     sscanf(RS[i],"RS\t%d\t%lf\t%lf\t",&val,&pp->times[i],&pp->params[i]);
-    assert(val==i);
+    ASSERT(val==i);
   }
   fprintf(stderr,"\t-> Done reading parameters from file: \'%s\'\n",fname);
 }

--- a/misc/misc.h
+++ b/misc/misc.h
@@ -1,0 +1,3 @@
+#ifndef ASSERT
+#define ASSERT(expr) if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s\n",__FILE__,__LINE__,#expr);exit(1);}
+#endif

--- a/misc/msHOT2glf.c
+++ b/misc/msHOT2glf.c
@@ -11,8 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 
 int block = 100;

--- a/misc/msHOT2glf.c
+++ b/misc/msHOT2glf.c
@@ -5,12 +5,14 @@
 #include <math.h>
 #include <pthread.h>
 #include <sys/stat.h>
-#include <assert.h>
 #include <htslib/kstring.h>
 #include <htslib/bgzf.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 
 int block = 100;
@@ -204,12 +206,14 @@ double Poisson(double xm)
 }
 
 int gv(char c){
-  if(c== '0')
+  if(c== '0'){
     return 0;
-  else if(c=='1')
+  }else if(c=='1'){
     return 1;
-  assert(1==0);
-  return -1;
+  }else{
+	  //never
+	  exit(1);
+  }
 }
 
 
@@ -310,7 +314,7 @@ int print_ind_site(double errate, double meandepth, int genotype[2],BGZF *glffil
 
   }
   if(glffile)
-    assert(sizeof(double)*10*bgzf_write(glffile,like,sizeof(double)*10));
+    ASSERT(sizeof(double)*10*bgzf_write(glffile,like,sizeof(double)*10));
   int noTrans =0;
   if(outfileSAF){
     // AA,AC,AG,AT,CC,CG,CT,GG,GT,TT
@@ -389,7 +393,7 @@ void test (int *positInt,BGZF *gz,double errate,double meandepth, int regLen,BGZ
     }
     if(kpsmc.l>0&&kpsmc.s[kpsmc.l-1]!='\n')
       ksprintf(&kpsmc,"\n");
-    assert(kpsmc.l==bgzf_write(gzPsmc,kpsmc.s,kpsmc.l));
+    ASSERT(kpsmc.l==bgzf_write(gzPsmc,kpsmc.s,kpsmc.l));
     kpsmc.l=0;
   }
   free(kpsmc.s);
@@ -499,7 +503,7 @@ int main(int argc,char **argv){
     pch=tmppch;
   }
   ss=sscanf(pch,"msHOT-lite %d %d -t %d -r %d %d\n", &nsam, &howmany,&theta,&rho,&regLen);
-  assert(ss==5);
+  ASSERT(ss==5);
   fprintf(stderr,"\t-> Number of samples:%d (haploids)\n",nsam);
   fprintf(stderr,"\t-> Number of replications:%d\n",howmany);
   fprintf(stderr,"\t-> theta: %d rho: %d regLen:%d\n",theta,rho,regLen);
@@ -557,7 +561,7 @@ int main(int argc,char **argv){
 	break;
     }
     if(tree!=NULL & tree_kstring.l>4096){
-      assert(tree_kstring.l==bgzf_write(tree,tree_kstring.s,tree_kstring.l));
+      ASSERT(tree_kstring.l==bgzf_write(tree,tree_kstring.s,tree_kstring.l));
       tree_kstring.l=0;
     }
     fprintf(stderr,"\t-> Parsing replicate:%d which should have nseg: %d ",i,segsites);
@@ -569,7 +573,7 @@ int main(int argc,char **argv){
     }
     int newlen;
     int rv = sscanf(line,"%d\n",&newlen);
-    assert(rv==1&&newlen==regLen);
+    ASSERT(rv==1&&newlen==regLen);
     for(int n=0;n<segsites;n++){
       if( fgets( line, 1000, pfin) == NULL ){
 	fprintf(stderr,"\t-> Problem reading file\n");
@@ -581,7 +585,7 @@ int main(int argc,char **argv){
       }      
       int at;
       ss=sscanf(line,"%d ",&at);
-      assert(ss=1);
+      ASSERT(ss=1);
       positInt[at]=1;
     }
     
@@ -608,7 +612,7 @@ int main(int argc,char **argv){
   fprintf(aDepthFP,"%lu\n",adepth[i]);
   fclose(aDepthFP);
   if(tree){
-    assert(tree_kstring.l==bgzf_write(tree,tree_kstring.s,tree_kstring.l));
+    ASSERT(tree_kstring.l==bgzf_write(tree,tree_kstring.s,tree_kstring.l));
     bgzf_close(tree);
   }
    if(psmcfa)

--- a/misc/msToGlf.c
+++ b/misc/msToGlf.c
@@ -6,7 +6,6 @@
 #include <math.h>
 #include <pthread.h>
 #include <sys/stat.h>
-#include <assert.h>
 #include <htslib/kstring.h>
 int static z_rndu=137;
 
@@ -112,12 +111,13 @@ double Poisson(double xm)
 }
 
 int gv(char c){
-  if(c== '0')
+  if(c== '0'){
     return 0;
-  else if(c=='1')
+  }else if(c=='1'){
     return 1;
-  assert(1==0);
-  return -1;
+  }else{
+	  exit(1);
+  }
 }
 
 

--- a/misc/ngsPSMC.cpp
+++ b/misc/ngsPSMC.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <cfloat>
 #include <signal.h>
-#include <cassert>
 #include <pthread.h>
 #include <unistd.h>
 #include <zlib.h>

--- a/misc/psmcreader.cpp
+++ b/misc/psmcreader.cpp
@@ -5,11 +5,7 @@
 #include "header.h"
 #include "psmcreader.h"
 
-
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
-
+#include "misc.h"
 
 
 void destroy(myMap &mm){

--- a/misc/psmcreader.cpp
+++ b/misc/psmcreader.cpp
@@ -7,6 +7,11 @@
 
 
 
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
+
+
 void destroy(myMap &mm){
   for(myMap::iterator it=mm.begin();it!=mm.end();++it)
     free(it->first);
@@ -81,7 +86,7 @@ perpsmc * perpsmc_init(char *fname){
     exit(0);
   }
   char buf[8];
-  assert(fread(buf,1,8,fp)==8);
+  ASSERT(fread(buf,1,8,fp)==8);
   ret->version = psmcversion(fname);
   fprintf(stderr,"\t-> Version of fname: \'%s\' is:%d\n",fname,ret->version);
   if(ret->version!=1){
@@ -91,7 +96,7 @@ perpsmc * perpsmc_init(char *fname){
   ret->nSites =0;
   while(fread(&clen,sizeof(size_t),1,fp)){
     char *chr = (char*)malloc(clen+1);
-    assert(clen==fread(chr,1,clen,fp));
+    ASSERT(clen==fread(chr,1,clen,fp));
     chr[clen] = '\0';
     
     datum d;
@@ -142,7 +147,7 @@ perpsmc * perpsmc_init(char *fname){
     fprintf(stderr,"Problem with mismatch of version of %s vs %s\n",fname,tmp2);
     exit(0);
   }
-  //assert(ret->pos!=NULL&&ret->saf!=NULL);
+  //ASSERT(ret->pos!=NULL&&ret->saf!=NULL);
   free(tmp);free(tmp2);
   
  return ret;
@@ -150,7 +155,7 @@ perpsmc * perpsmc_init(char *fname){
 
  //chr start stop is given from commandine
  myMap::iterator iter_init(perpsmc *pp,char *chr,int start,int stop){
-   assert(chr!=NULL);
+   ASSERT(chr!=NULL);
    myMap::iterator it = pp->mm.find(chr);
    if(it==pp->mm.end()){
      fprintf(stderr,"\t-> [%s] Problem finding chr: %s\n",__FUNCTION__,chr);

--- a/misc/psmcreader.h
+++ b/misc/psmcreader.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstring>
 #include <cstdlib>
-#include <cassert>
 #include <map>
 #include <htslib/bgzf.h>
 #include "header.h"

--- a/misc/realSFS.cpp
+++ b/misc/realSFS.cpp
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <cfloat>
 #include <signal.h>
-#include <cassert>
 #include <pthread.h>
 #include <unistd.h>
 #include <zlib.h>
@@ -43,6 +42,7 @@ int howOften =5e6;//how often should we print out (just to make sure something i
 #include "../aio.h"
 int really_kill =3;
 int VERBOSE = 1;
+
 
 extern std::vector <char *> dumpedFiles;
 
@@ -350,7 +350,7 @@ int print_multi(args *arg)
   //fprintf(stderr,"[%s]\n",__FUNCTION__);
   std::vector<persaf *> &saf = arg->saf;
   for(int i=0;i<saf.size();i++)
-    assert(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
+    ASSERT(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
 
   size_t nSites = arg->nSites;
   if(nSites == 0) //if no -nSites is specified
@@ -556,7 +556,7 @@ int fst_index(int argc,char **argv){
   }
 
   std::vector<persaf *> &saf =arg->saf;
-  //assert(saf.size()==2);
+  //ASSERT(saf.size()==2);
   size_t nSites = arg->nSites;
   if(nSites == 0){//if no -nSites is specified
     nSites = 100000;//<- set default to 100k sites, no need to load everything...
@@ -707,7 +707,7 @@ int fst_index(int argc,char **argv){
     fwrite(it->first,1,clen,fstfp);
     size_t nit=posi.size();
 
-    assert(1==fwrite(&nit,sizeof(size_t),1,fstfp));
+    ASSERT(1==fwrite(&nit,sizeof(size_t),1,fstfp));
     int64_t tell = bgzf_tell(fstbg);
     fwrite(&tell,sizeof(int64_t),1,fstfp);
     my_bgzf_write(fstbg,&posi[0],posi.size()*sizeof(int));
@@ -763,12 +763,12 @@ int fst(int argc,char**argv){
 // --- realSFS saf2theta --- //
 
 void writeAllThetas(BGZF *dat,FILE *idx,char *tmpChr,int64_t &offs,std::vector<int> &p,std::vector<float> *res,int nChr){
-  assert(dat!=NULL);
-  assert(idx!=NULL);
-  assert(p.size()==res[0].size());
+  ASSERT(dat!=NULL);
+  ASSERT(idx!=NULL);
+  ASSERT(p.size()==res[0].size());
   fprintf(stderr,"\t-> Writing %lu sites for chr:%s\n",p.size(),tmpChr);
   for(int i=1;i<5;i++)
-    assert(p.size()==res[i].size());//DRAGON, might be discarded during compilation
+    ASSERT(p.size()==res[i].size());//DRAGON, might be discarded during compilation
       
   if(p.size()!=0&&tmpChr!=NULL){
     //write clen and chromoname for both index and bgzf

--- a/misc/realSFS.old.cpp
+++ b/misc/realSFS.old.cpp
@@ -22,7 +22,6 @@
 #include <cmath>
 #include <cfloat>
 #include <signal.h>
-#include <cassert>
 #include <pthread.h>
 
 #ifdef __APPLE__
@@ -34,6 +33,9 @@
 #include "realSFS.h"
 #include "realSFS_saf2.cpp"
 #define LENS 4096
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 const char*fname1 = NULL;
 const char*fname2 = NULL;//only used for 2dsfs
@@ -998,7 +1000,7 @@ int main_2dsfs(int argc,char **argv){
       readGL2(gz2,nSites,chr2,GL2);
     }
       
-    assert(GL1.x==GL2.x);
+    ASSERT(GL1.x==GL2.x);
     if(GL1.x==0)
       break;
     
@@ -1106,8 +1108,8 @@ int main_3dsfs(int argc,char **argv){
       readGL2(gz3,nSites,chr3,GL3);
     }
       
-    assert(GL1.x==GL2.x);
-    assert(GL1.x==GL3.x);
+    ASSERT(GL1.x==GL2.x);
+    ASSERT(GL1.x==GL3.x);
     if(GL1.x==0)
       break;
     

--- a/misc/realSFS.old.cpp
+++ b/misc/realSFS.old.cpp
@@ -34,8 +34,7 @@
 #include "realSFS_saf2.cpp"
 #define LENS 4096
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 const char*fname1 = NULL;
 const char*fname2 = NULL;//only used for 2dsfs

--- a/misc/realSFS_dadi.cpp
+++ b/misc/realSFS_dadi.cpp
@@ -4,11 +4,10 @@
 #include "realSFS_dadi.h"
 #include "realSFS_shared.h"
 #include <htslib/faidx.h>
+#include "misc.h"
 extern int howOften;
 #include "multisafreader.hpp"
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 faidx_t *fai_ref=NULL;
 faidx_t *fai_anc=NULL;

--- a/misc/realSFS_dadi.cpp
+++ b/misc/realSFS_dadi.cpp
@@ -7,6 +7,9 @@
 extern int howOften;
 #include "multisafreader.hpp"
 
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
 faidx_t *fai_ref=NULL;
 faidx_t *fai_anc=NULL;
 char *ref=NULL;
@@ -15,7 +18,7 @@ int ref_l=0;
 int anc_l=0;
 
 int whichmax(double *ary,int len){
-  assert(len>0);
+  ASSERT(len>0);
   int mmax = 0;
   for(int i=1;i<len;i++)
     if(ary[i]>ary[mmax])
@@ -95,7 +98,7 @@ int main_dadi(int argc, char** argv){
   if(saf.size()==1)
     saf[0]->kind = 2;
   for(int i=0;i<saf.size();i++)
-    assert(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
+    ASSERT(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
   if(saf.size()!=arg->sfsfname.size()){
     fprintf(stderr,"\t-> Must supply a perpopulation prior for each population\n");
     return 0;

--- a/misc/realSFS_optim.cpp
+++ b/misc/realSFS_optim.cpp
@@ -5,6 +5,8 @@
 #include "realSFS_optim.h"
 extern int howOften;
 #include "multisafreader.hpp"
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 void readSFS(const char *fname, size_t hint, double *ret);
 
 size_t * foldremapper = NULL;
@@ -39,7 +41,7 @@ size_t sfs_linear_index (int *bin, int *nchr, int npop, bool rev);
 template <typename T>
 double lik(double *sfs, std::vector< Matrix<T> *> &gls, size_t from, size_t to)
 {
-  assert(from >= 0 && to >=0);
+  ASSERT(from >= 0 && to >=0);
   double r = 0;
   size_t ss, lind;
 
@@ -478,7 +480,7 @@ int main_opt(args *arg){
    
   std::vector<persaf *> &saf =arg->saf;
   for(int i=0;i<saf.size();i++)
-    assert(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
+    ASSERT(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
   size_t nSites = arg->nSites;
   if(nSites == 0){//if no -nSites is specified
     nSites=calc_nsites(saf,arg);
@@ -669,7 +671,7 @@ int main_opt2(args *arg){
   
   std::vector<persaf *> &saf =arg->saf;
   for(int i=0;i<saf.size();i++)
-    assert(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
+    ASSERT(saf[i]->pos!=NULL&&saf[i]->saf!=NULL);
   size_t nSites = arg->nSites;
   if(nSites == 0){//if no -nSites is specified
     nSites=calc_nsites(saf,arg);

--- a/misc/realSFS_optim.cpp
+++ b/misc/realSFS_optim.cpp
@@ -5,8 +5,7 @@
 #include "realSFS_optim.h"
 extern int howOften;
 #include "multisafreader.hpp"
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 void readSFS(const char *fname, size_t hint, double *ret);
 
 size_t * foldremapper = NULL;

--- a/misc/realSFS_shared.cpp
+++ b/misc/realSFS_shared.cpp
@@ -1,8 +1,6 @@
 #include "realSFS_shared.h"
+#include "misc.h"
 int **posiG  = NULL;
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 //unthreaded
 //this will populate the keep vector by

--- a/misc/realSFS_shared.cpp
+++ b/misc/realSFS_shared.cpp
@@ -1,6 +1,9 @@
 #include "realSFS_shared.h"
 int **posiG  = NULL;
 
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
 //unthreaded
 //this will populate the keep vector by
 // 1) set the chooseChr and populate toKeep
@@ -39,7 +42,7 @@ int set_intersect_pos(std::vector<persaf *> &saf,char *chooseChr,int start,int s
   }
   fprintf(stderr,"\t-> hello Im the master merge part of realSFS. and I'll now do a tripple bypass to find intersect \n");
   fprintf(stderr,"\t-> 1) Will set iter according to chooseChr and start and stop, and possibly using -sites\n");
-  assert(chooseChr!=NULL);
+  ASSERT(chooseChr!=NULL);
   //check that chooseChr exists in all pops.
   for(int j=0;j<saf.size();j++){
     myMap::iterator it = saf[j]->mm.find(chooseChr);
@@ -71,7 +74,7 @@ int set_intersect_pos(std::vector<persaf *> &saf,char *chooseChr,int start,int s
     }
 
     //    fprintf(stderr,"ASDFASDF:%p\n",saf[i]->ppos);
-    //    assert(it!=saf[i]->mm.end());  
+    //    ASSERT(it!=saf[i]->mm.end());  
     if(it==saf[i]->mm.end()){
       killbreak =1;
       break;
@@ -81,7 +84,7 @@ int set_intersect_pos(std::vector<persaf *> &saf,char *chooseChr,int start,int s
       return 0;
     }if(saf[i]->ppos[it->second.nSites-1] >= hit->m)
     realloc(hit,saf[i]->ppos[it->second.nSites-1]+1);
-    assert(hit->m>0);
+    ASSERT(hit->m>0);
     for(size_t j=saf[i]->toKeep->first;j<=saf[i]->toKeep->last;j++){
       if(j>saf[i]->toKeep->first&&saf[i]->ppos[j] <= saf[i]->ppos[j-1]){
         fprintf(stderr,"\t-> Potential big problem, ordering of positions indicates that sites has not been sorted ? \n");
@@ -126,7 +129,7 @@ int set_intersect_pos(std::vector<persaf *> &saf,char *chooseChr,int start,int s
     fprintf(stderr,"\t-> Sites to keep[%s] from pop%d:\t%d\n",chooseChr,i,tsk[i]);
     hasdata +=tsk[i];
     if(i>0)
-      assert(tsk[i]==tsk[i-1]);
+      ASSERT(tsk[i]==tsk[i-1]);
 #if 0
     keep_info(saf[i]->toKeep,stderr,0,1);
     //print out overlapping positions for all pops
@@ -222,7 +225,7 @@ size_t fsizes(std::vector<persaf *> &pp, size_t nSites){
     return fsizes_v2<T>(pp,nSites);
   if(pp[0]->version==3)
     return fsizes_v3<T>(pp,nSites);
-  assert(0!=0);
+  ASSERT(0!=0);
   return 0;
 }
 

--- a/misc/saf_convert.cpp
+++ b/misc/saf_convert.cpp
@@ -6,9 +6,7 @@
 
 #include "safcat.h"
 #include "header.h"
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 int main_text2safv4(int argc,char **argv){
   fprintf(stderr,"\t-> This will convert a banded text saf file into safv3 file\n");

--- a/misc/saf_convert.cpp
+++ b/misc/saf_convert.cpp
@@ -3,10 +3,12 @@
 #include <cstdlib>
 #include <htslib/bgzf.h>
 #include <htslib/kstring.h>
-#include <cassert>
 
 #include "safcat.h"
 #include "header.h"
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 int main_text2safv4(int argc,char **argv){
   fprintf(stderr,"\t-> This will convert a banded text saf file into safv3 file\n");
@@ -41,7 +43,7 @@ int main_text2safv4(int argc,char **argv){
   
   BGZF *infilefp = NULL;
   infilefp = bgzf_open(infile,"rb");
-  assert(infilefp!=NULL);
+  ASSERT(infilefp!=NULL);
    
   BGZF *outfileSAF =  openFileBG(outnames,SAF);
   BGZF *outfileSAFPOS =  openFileBG(outnames,SAFPOS);
@@ -58,7 +60,7 @@ int main_text2safv4(int argc,char **argv){
   fwrite(buf,1,8,outfileSAFIDX);
   fwrite(&nchr,sizeof(size_t),1,outfileSAFIDX);
   int64_t offs[2];
-  assert(0==bgzf_flush(outfileSAFPOS));assert(0==bgzf_flush(outfileSAF));
+  ASSERT(0==bgzf_flush(outfileSAFPOS));ASSERT(0==bgzf_flush(outfileSAF));
   offs[0] = bgzf_tell(outfileSAFPOS);
   offs[1] = bgzf_tell(outfileSAF);
 
@@ -90,10 +92,10 @@ int main_text2safv4(int argc,char **argv){
       sumband =0;
       free(chr);
       chr= strdup(tmpChr);
-      assert(bgzf_write(outfileSAFPOS, pos.data(), sizeof(int)*pos.size())==sizeof(int)*pos.size());
+      ASSERT(bgzf_write(outfileSAFPOS, pos.data(), sizeof(int)*pos.size())==sizeof(int)*pos.size());
       pos.clear();
-      assert(0==bgzf_flush(outfileSAF));
-      assert(0==bgzf_flush(outfileSAFPOS));
+      ASSERT(0==bgzf_flush(outfileSAF));
+      ASSERT(0==bgzf_flush(outfileSAFPOS));
       offs[0] = bgzf_tell(outfileSAFPOS);
       offs[1] = bgzf_tell(outfileSAF);
     }
@@ -121,8 +123,8 @@ int main_text2safv4(int argc,char **argv){
       flt[i] = atof(strtok(NULL,"\t\n "));
       //      fprintf(stderr,"flt[%d]: %f\n",i,flt[i]);
     }
-    assert(bgzf_write(outfileSAF, bin_len, sizeof(int)*2)==sizeof(int)*2);
-    assert(bgzf_write(outfileSAF, flt, sizeof(float)*bin_len[1])==sizeof(float)*bin_len[1]);
+    ASSERT(bgzf_write(outfileSAF, bin_len, sizeof(int)*2)==sizeof(int)*2);
+    ASSERT(bgzf_write(outfileSAF, flt, sizeof(float)*bin_len[1])==sizeof(float)*bin_len[1]);
   }
 
   if(sumband>0){
@@ -136,7 +138,7 @@ int main_text2safv4(int argc,char **argv){
     fwrite(&sumband,sizeof(size_t),1,outfileSAFIDX);
     fwrite(offs,sizeof(int64_t),2,outfileSAFIDX);
     //    fprintf(stderr,"nsites: %lu\n",pos.size());
-    assert(bgzf_write(outfileSAFPOS, pos.data(), sizeof(int)*pos.size())==sizeof(int)*pos.size());
+    ASSERT(bgzf_write(outfileSAFPOS, pos.data(), sizeof(int)*pos.size())==sizeof(int)*pos.size());
     sumband =0;
   }
   

--- a/misc/safcat.cpp
+++ b/misc/safcat.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 #include <cfloat>
 #include <signal.h>
-#include <cassert>
 #include <unistd.h>
 #include <zlib.h>
 #include <htslib/tbx.h>
@@ -24,6 +23,10 @@
 #include "realSFS_args.h"
 #include <fstream>
 
+
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 std::vector<char*> getFilenames(const char * name,int nInd){
   fprintf(stderr,"\t-> Reading saf.idx from: %s\n",name);
@@ -125,7 +128,7 @@ int saf_cat(int argc,char **argv){
   my_bgzf_write(outfileSAFPOS,buf,8);
   fwrite(buf,1,8,outfileSAFIDX);
   int64_t offs[2];
-  assert(0==bgzf_flush(outfileSAFPOS));assert(0==bgzf_flush(outfileSAF));
+  ASSERT(0==bgzf_flush(outfileSAFPOS));ASSERT(0==bgzf_flush(outfileSAF));
   offs[0] = bgzf_tell(outfileSAFPOS);
   offs[1] = bgzf_tell(outfileSAF);
   
@@ -169,7 +172,7 @@ int saf_cat(int argc,char **argv){
       if(safversion==3)
 	fwrite(&it->second.sumBand,sizeof(size_t),1,outfileSAFIDX);
       fwrite(offs,sizeof(int64_t),2,outfileSAFIDX);
-      assert(0==bgzf_flush(outfileSAFPOS));assert(0==bgzf_flush(outfileSAF));
+      ASSERT(0==bgzf_flush(outfileSAFPOS));ASSERT(0==bgzf_flush(outfileSAF));
       offs[0] = bgzf_tell(outfileSAFPOS);
       offs[1] = bgzf_tell(outfileSAF);
     }
@@ -193,7 +196,7 @@ int saf_check(int argc,char **argv) {
   if(argc==0)
     return 0;
   args *pars = getArgs(argc,argv);
-  assert(pars->saf.size()==1);
+  ASSERT(pars->saf.size()==1);
   for(myMap::iterator it=pars->saf[0]->mm.begin();it!=pars->saf[0]->mm.end();++it){
     int *ppos = new int[it->second.nSites];
     my_bgzf_seek(pars->saf[0]->pos,it->second.pos,SEEK_SET);

--- a/misc/safcat.cpp
+++ b/misc/safcat.cpp
@@ -22,11 +22,7 @@
 #include "safcat.h"
 #include "realSFS_args.h"
 #include <fstream>
-
-
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 std::vector<char*> getFilenames(const char * name,int nInd){
   fprintf(stderr,"\t-> Reading saf.idx from: %s\n",name);

--- a/misc/safreader.cpp
+++ b/misc/safreader.cpp
@@ -2,9 +2,7 @@
 #include <htslib/bgzf.h>
 #include <zlib.h>
 #include "safreader.h"
-
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+#include "misc.h"
 
 
 void destroy(myMap &mm)

--- a/misc/safreader.cpp
+++ b/misc/safreader.cpp
@@ -3,6 +3,10 @@
 #include <zlib.h>
 #include "safreader.h"
 
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
+
 void destroy(myMap &mm)
 {
   for(myMap::iterator it=mm.begin();it!=mm.end();++it)
@@ -101,7 +105,7 @@ persaf * persaf_init(char *fname, int verbose)
   }
 
   char buf[8];
-  assert(fread(buf,1,8,fp)==8);
+  ASSERT(fread(buf,1,8,fp)==8);
   ret->version = safversion(fname);
   
   if(verbose)
@@ -120,7 +124,7 @@ persaf * persaf_init(char *fname, int verbose)
   while(fread(&clen,sizeof(size_t),1,fp))
   {
     char *chr = (char*)malloc(clen+1);
-    assert(clen==fread(chr,1,clen,fp));
+    ASSERT(clen==fread(chr,1,clen,fp));
     chr[clen] = '\0';
 
     datum d;
@@ -195,7 +199,7 @@ persaf * persaf_init(char *fname, int verbose)
     exit(0);
   }
 
-  //assert(ret->pos!=NULL&&ret->saf!=NULL);
+  //ASSERT(ret->pos!=NULL&&ret->saf!=NULL);
   free(tmp);
   free(tmp2);
 
@@ -210,7 +214,7 @@ myMap::iterator iter_init(persaf *pp, char *chr, int start, int stop)
 {
   //  fprintf(stderr,"kind:%d start:%d stop:%d dontread:%d\n",pp->kind,start,stop,pp->dontRead);
   pp->dontRead = 0;
-  assert(chr!=NULL);
+  ASSERT(chr!=NULL);
   myMap::iterator it = pp->mm.find(chr);
   if(it==pp->mm.end()){
     fprintf(stderr,"\t-> [%s] Problem finding chr: %s\n",__FUNCTION__,chr);
@@ -271,7 +275,7 @@ myMap::iterator iter_init(persaf *pp, char *chr, int start, int stop)
 template <typename T>
 size_t iter_read(persaf *saf, T *&data, T *buffer, int *pos)
 {
-  assert(buffer);
+  ASSERT(buffer);
   
   int band[2];
   
@@ -290,7 +294,7 @@ size_t iter_read(persaf *saf, T *&data, T *buffer, int *pos)
     ret = bgzf_read(saf->saf, band, 2*sizeof(int));
     if (ret==0)
       return ret;
-    assert(ret == 2*sizeof(int));
+    ASSERT(ret == 2*sizeof(int));
   }
   else
   {
@@ -301,7 +305,7 @@ size_t iter_read(persaf *saf, T *&data, T *buffer, int *pos)
   ret = saf->kind!=1 ? bgzf_read(saf->saf, buffer, band[1]*sizeof(T)) : band[1];
   if(ret==0)
     return ret;
-  assert(ret==band[1]*sizeof(T) && band[0]+band[1]<=saf->nChr+1);
+  ASSERT(ret==band[1]*sizeof(T) && band[0]+band[1]<=saf->nChr+1);
 
   saf->at++;
   //   fprintf(stdout,"saf->at:%d ret:%d\n",saf->at,ret);

--- a/misc/safreader.h
+++ b/misc/safreader.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstring>
 #include <cstdlib>
-#include <cassert>
 #include <map>
 #include <htslib/bgzf.h>
 #include "keep.hpp"

--- a/misc/safstat.cpp
+++ b/misc/safstat.cpp
@@ -85,7 +85,7 @@ void calcCoef(int sfs1,int sfs2,double **aMat,double **bMat,int whichFst){
 }
 
 void block_coef(Matrix<float > *gl1,Matrix<float> *gl2,double *prior,double *a1,double *b1,std::vector<double> &ares,std::vector<double> &bres,int *remap,int *rescal){
-  assert(prior!=NULL);
+  if(prior==NULL) exit(1);
 
   double snyd1[gl1->y];
   double snyd2[gl2->y];

--- a/misc/scounts.cpp
+++ b/misc/scounts.cpp
@@ -7,9 +7,8 @@
 #include <vector>
 #include <map>
 #include <libgen.h>
+#include "misc.h"
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 typedef unsigned char uchar;
 

--- a/misc/scounts.cpp
+++ b/misc/scounts.cpp
@@ -2,12 +2,15 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
-#include <cassert>
 #include <zlib.h>
 #include <sys/stat.h>
 #include <vector>
 #include <map>
 #include <libgen.h>
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
+
 typedef unsigned char uchar;
 
 typedef struct{

--- a/misc/smartCount.c
+++ b/misc/smartCount.c
@@ -7,9 +7,8 @@
 #include "kvec.h"
 #include <libgen.h>
 #define LENS  4096
+#include "misc.h"
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 const char * BIN= ".counts.bin";
 const char * IDX= ".counts.idx";

--- a/misc/smartCount.c
+++ b/misc/smartCount.c
@@ -1,13 +1,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zlib.h>
-#include <assert.h>
 #include <sys/stat.h>
 #include "bgzf.h"
 #include "khash.h"
 #include "kvec.h"
 #include <libgen.h>
 #define LENS  4096
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 const char * BIN= ".counts.bin";
 const char * IDX= ".counts.idx";
@@ -387,7 +389,7 @@ char sample(int a,int b,int c,int d){
 }
 
 int doAnal(perChr *pc,int nInd){
-  assert(nInd>1);
+  ASSERT(nInd>1);
   //  fprintf(stderr,"[%s] chr:%s\n",__FUNCTION__,pc[0].chr);
   //validate same reference lengths
   for(int i=1;i<nInd;i++)

--- a/misc/splitgl.c
+++ b/misc/splitgl.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <zlib.h>
 #include <stdlib.h>
-#include <assert.h>
 
 gzFile getGz(const char*fname,const char* mode){
   gzFile fp=Z_NULL;
@@ -39,7 +38,7 @@ int main(int argc,char**argv){
     if(br==0)
       break;
     nsites++;
-    assert(br==10*sizeof(double)*tot);
+    if(br!=10*sizeof(double)*tot) exit(1);
     int beg=10*first;
     int nDoubles=(last-first+1)*10;
     //   fprintf(stderr,"beg: %d nDoubles:%d\n",beg,nDoubles);return 0;

--- a/misc/thetaStat.cpp
+++ b/misc/thetaStat.cpp
@@ -7,9 +7,8 @@
 #include <htslib/bgzf.h>
 #include <htslib/kstring.h>
 #include "stats.cpp"
+#include "misc.h"
 
-#define ASSERT(expr) \
-	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 const char * BIN= ".bin";
 const char * IDX= ".idx";

--- a/misc/thetaStat.cpp
+++ b/misc/thetaStat.cpp
@@ -7,7 +7,9 @@
 #include <htslib/bgzf.h>
 #include <htslib/kstring.h>
 #include "stats.cpp"
-#include <cassert>
+
+#define ASSERT(expr) \
+	if (!(expr)) {fprintf(stderr,"[ERROR](%s:%d) %s",__FILE__,__LINE__,#expr);exit(1);}
 
 const char * BIN= ".bin";
 const char * IDX= ".idx";
@@ -36,7 +38,7 @@ typedef struct{
 typedef std::map<char*,datum,ltstr> myMap;
 //ssize_t bgzf_read(BGZF *fp, void *data, size_t length) HTS_RESULT_USED;
 void my_bgzf_read(BGZF *fp, void *data, size_t length){
-  assert(length==bgzf_read(fp,data,length));
+  ASSERT(length==bgzf_read(fp,data,length));
 }
 
 int isok(char *bgzf_name,char *fp_name){
@@ -47,7 +49,7 @@ int isok(char *bgzf_name,char *fp_name){
     return 0;
   }
   char buf[8];
-  assert(8==fread(buf,sizeof(char),8,fp));
+  ASSERT(8==fread(buf,sizeof(char),8,fp));
   if(strcmp(buf,"thetav2")!=0){
     fprintf(stderr,"\t-> It looks like input files have been generated with an older version of ANGSD. Either use older version of angsd <0.915 or rerun main angsd with later version of angsd >0.917 magicnr:\'%s\'\n",buf);
     return 0;
@@ -60,7 +62,7 @@ int isok(char *bgzf_name,char *fp_name){
     fprintf(stderr,"\t-> Problems opening file: \'%s\'\n",bgzf_name);
     return 0;
   }
-  assert(8==bgzf_read(bgzf,buf,8*sizeof(char)));
+  ASSERT(8==bgzf_read(bgzf,buf,8*sizeof(char)));
   if(strcmp(buf,"thetav2")!=0){
     fprintf(stderr,"\t-> It looks like input files have been generated with an older version of ANGSD. Either use older version of angsd <0.915 or rerun main angsd with later version of angsd >0.917 magicnr:\'%s\'\n",buf);
     return 0;
@@ -109,10 +111,10 @@ myMap getMap(const char *fname){
   }
   FILE *fp = fopen(fname,"r");
   char tmp[8];
-  assert(8==fread(tmp,1,8,fp));
+  ASSERT(8==fread(tmp,1,8,fp));
   while(fread(&clen,sizeof(size_t),1,fp)){
     char *chr = new char[clen+1];
-    assert(clen==fread(chr,1,clen,fp));
+    ASSERT(clen==fread(chr,1,clen,fp));
     chr[clen] = '\0';
 
     datum d;
@@ -408,7 +410,7 @@ int do_stat(int argc, char**argv){
       exit(0);
     }
     datum d = it->second;
-    assert(bgzf_seek(fp,d.fpos,SEEK_SET)==0);
+    ASSERT(bgzf_seek(fp,d.fpos,SEEK_SET)==0);
   }
   if(outnames==NULL)
     outnames = base;
@@ -498,7 +500,7 @@ int print(int argc, char**argv){
       exit(0);
     }
     datum d = it->second;
-    assert(0==bgzf_seek(fp,d.fpos,SEEK_SET));
+    ASSERT(0==bgzf_seek(fp,d.fpos,SEEK_SET));
   }
   fprintf(stdout,"#Chromo\tPos\tWatterson\tPairwise\tthetaSingleton\tthetaH\tthetaL\n");
   while(1){

--- a/mpileup.cpp
+++ b/mpileup.cpp
@@ -30,7 +30,7 @@ tNode **parseNd(char *line,int nInd,const char *delims,int minQ,char ref){
   for(int i=0;i<nInd;i++) {
 
     char *tok = strtok_r(NULL,delims,&line);
-    aio::doAssert(tok==NULL,1,AT,"");
+    aio::doAssert(tok!=NULL,AT);
     int seqDepth = atoi(tok);
     ret[i] = initNodeT(seqDepth);
     ret[i]->l = seqDepth;

--- a/mpileup.cpp
+++ b/mpileup.cpp
@@ -1,5 +1,4 @@
 #include <ctype.h>
-#include <cassert>
 #include "pooled_alloc.h"
 #include "mpileup.h"
 #include "mUpPile.h"
@@ -31,7 +30,7 @@ tNode **parseNd(char *line,int nInd,const char *delims,int minQ,char ref){
   for(int i=0;i<nInd;i++) {
 
     char *tok = strtok_r(NULL,delims,&line);
-    assert(tok);
+    aio::doAssert(tok==NULL,1,AT,"");
     int seqDepth = atoi(tok);
     ret[i] = initNodeT(seqDepth);
     ret[i]->l = seqDepth;

--- a/multiReader.cpp
+++ b/multiReader.cpp
@@ -43,7 +43,7 @@ bam_hdr_t *getHeadFromFai(const char *fname){
 }
 
 aMap *buildRevTable(const bam_hdr_t *hd){
-  aio::doAssert(hd==NULL,1,AT,"");
+  aio::doAssert(hd!=NULL,AT);
   aMap *ret = new aMap;
   for(int i=0;i<hd->n_targets;i++){
     ret->insert(std::pair<char *,int>(strdup(hd->target_name[i]),i));

--- a/multiReader.cpp
+++ b/multiReader.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include "abc.h"
 #include "shared.h"
 #include "multiReader.h"
@@ -44,7 +43,7 @@ bam_hdr_t *getHeadFromFai(const char *fname){
 }
 
 aMap *buildRevTable(const bam_hdr_t *hd){
-  assert(hd);
+  aio::doAssert(hd==NULL,1,AT,"");
   aMap *ret = new aMap;
   for(int i=0;i<hd->n_targets;i++){
     ret->insert(std::pair<char *,int>(strdup(hd->target_name[i]),i));

--- a/pop1_read.cpp
+++ b/pop1_read.cpp
@@ -9,7 +9,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cassert>
 #include <ctype.h>
 #include <cmath>
 #include <htslib/hts.h>
@@ -19,6 +18,7 @@
 #include "abcGetFasta.h"
 #include "cigstat.h"
 #include "from_samtools.h"
+#include "aio.h"
 
 //three externs below are from
 extern int uniqueOnly;
@@ -62,16 +62,16 @@ int getNumBest(bam1_t *b) {
 int restuff(bam1_t *b){
   //  fprintf(stderr,"ohh yes: b.refID=%d b.pos=%d\n",b.refID,b.pos);
  extern abcGetFasta *gf;
- assert(gf->ref->curChr==b->core.tid);
+ aio::doAssert(gf->ref->curChr==b->core.tid,1,AT,"");
 
  if(baq){
-   assert(gf->ref!=NULL);
-   assert(gf->ref->curChr==b->core.tid);
+   aio::doAssert(gf->ref!=NULL,1,AT,"");
+   aio::doAssert(gf->ref->curChr==b->core.tid,1,AT,"");
    sam_prob_realn(b,gf->ref->seqs,gf->ref->chrLen,baq);
  }
 
  if(adjustMapQ!=0){
-   assert(gf->ref!=NULL);
+   aio::doAssert(gf->ref!=NULL,1,AT,"");
    int q = sam_cap_mapq(b,gf->ref->seqs,gf->ref->chrLen,adjustMapQ);
    if(q<0)
      return 0;
@@ -139,7 +139,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
     if(uniqueOnly==0&&only_proper_pairs==0 &&remove_bads==0&&minMapQ==0&&adjustMapQ==0&&baq==0){
       //fprintf(stderr,"r:%d\n",r);
       if(cigstat)
-	assert(cigstat_calc(b)==0);
+	aio::doAssert(cigstat_calc(b)==0,1,AT,"");
       return r;
     }
     
@@ -163,7 +163,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
     
     if(gf->ref!=NULL&&gf->ref->curChr==b->core.tid){
       if(adjustMapQ!=0){
-	assert(gf->ref!=NULL);
+	aio::doAssert(gf->ref!=NULL,1,AT,"");
 	int q = sam_cap_mapq(b,gf->ref->seqs,gf->ref->chrLen,adjustMapQ);
 	if(q<0)
 	  goto bam_iter_reread;
@@ -177,7 +177,7 @@ int pop1_read(htsFile *fp, hts_itr_t *itr,bam1_t *b,bam_hdr_t *hdr) {
   }
   // fprintf(stderr,"r:%d\n",r);
   if(cigstat)
-    assert(cigstat_calc(b)==0);
+    aio::doAssert(cigstat_calc(b)==0,1,AT,"");
   return r; 
 }
 

--- a/prep_sites.cpp
+++ b/prep_sites.cpp
@@ -5,13 +5,14 @@
   g++ prep_sites.cpp -D__WITH_MAIN__ bgzf.o knetfile.o -lz analysisFunction.o -ggdb
 */
 
+
+
 #ifdef __WITH_MAIN__
 #endif
 
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include <cassert>
 #define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 #include "prep_sites.h"
 #include "aio.h"
@@ -45,7 +46,7 @@ void dalloc(tary<T> *ta){
 
 //hint is the suggested newsize
 void filt_readSites(filt*fl,char *chr,size_t hint) {
-  assert(fl!=NULL);
+  aio::doAssert(fl!=NULL, 1, AT,"fl is null");
 
   std::map<char*,asdf_dats,ltstr> ::iterator it = fl->offs.find(chr);
   if(it==fl->offs.end()){
@@ -66,7 +67,7 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
     return;
   }
 
-  assert(0==bgzf_seek(fl->bg,it->second.offs,SEEK_SET));
+  aio::doAssert(0==bgzf_seek(fl->bg,it->second.offs,SEEK_SET),1,AT,"0==bgzf_seek");
 
   size_t nsize = std::max(fl->curLen,hint);//this is not the number of elements, but the last position on the reference
   nsize = std::max(nsize,it->second.len)+1;//not sure if '+1' this is needed, but it doesnt hurt...
@@ -75,7 +76,7 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
     fl->keeps=(char*) realloc(fl->keeps,nsize);
   memset(fl->keeps,0,nsize);
   //fprintf(stderr,"it->second.len:%lu fl->curLen:%lu fl->keeps:%p\n",it->second.len,fl->curLen,fl->keeps);
-  assert(it->second.len==bgzf_read(fl->bg,fl->keeps,it->second.len));
+  aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->keeps,it->second.len),1,AT,"");
 
   if(fl->hasExtra>0){
     if(nsize>fl->curLen) {
@@ -84,8 +85,8 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
       memset(fl->major,0,nsize);
       memset(fl->minor,0,nsize);
     }
-    assert(it->second.len==bgzf_read(fl->bg,fl->major,it->second.len));
-    assert(it->second.len==bgzf_read(fl->bg,fl->minor,it->second.len));
+    aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->major,it->second.len),1,AT,"");
+    aio::doAssert(it->second.len==bgzf_read(fl->bg,fl->minor,it->second.len),1,AT,"");
   }
   if(fl->hasExtra>1){
     if(nsize>fl->curLen) {
@@ -96,9 +97,9 @@ void filt_readSites(filt*fl,char *chr,size_t hint) {
       memset(fl->an,0,nsize*sizeof(int));
       memset(fl->ac,0,nsize*sizeof(int));
     }
-    assert(it->second.len*sizeof(float)==bgzf_read(fl->bg,fl->af,it->second.len*sizeof(float)));
-    assert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->ac,it->second.len*sizeof(int)));
-    assert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->an,it->second.len*sizeof(int)));
+    aio::doAssert(it->second.len*sizeof(float)==bgzf_read(fl->bg,fl->af,it->second.len*sizeof(float)),1,AT,"");
+    aio::doAssert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->ac,it->second.len*sizeof(int)),1,AT,"");
+    aio::doAssert(it->second.len*sizeof(int)==bgzf_read(fl->bg,fl->an,it->second.len*sizeof(int)),1,AT,"");
   }
 
   fl->curNam=chr;
@@ -287,7 +288,7 @@ typedef std::map<char *,int,ltstr> mmap;
 
 //return zero if fine.
 int writeDat(char *last,mmap &mm,tary<char> *keep,tary<char> *major,tary<char> *minor,BGZF *BFP,FILE *fp,int doCompl,tary<float> *af,tary<int> *ac,tary<int> *an){
-  assert(last!=NULL);
+  aio::doAssert(last!=NULL,1,AT,"last is null");
   if((major!=NULL) ^ (minor!=NULL)){
     fprintf(stderr,"major and minor should be the same\n");
     return 1;
@@ -304,7 +305,7 @@ int writeDat(char *last,mmap &mm,tary<char> *keep,tary<char> *major,tary<char> *
   }else
     mm[strdup(last)]=1;
   //write data and index stuff
-  assert(0==bgzf_flush(BFP));
+  aio::doAssert(0==bgzf_flush(BFP),1,AT,"bgzf_flush!=0");
   int64_t retVal =bgzf_tell(BFP);//now contains the offset to which we should point.
   
   //write chrname
@@ -442,15 +443,15 @@ void filt_gen(const char *fname,int posi_off,int doCompl) {
 	memset(minor->d,4,keep->m);
 	major->l=minor->l=0;
       }
-      if(hasExtra>1)
-	assert(1);
+      // if(hasExtra>1)
+
     }
     char *position_in_sites_file = parsed[1];
-    assert(atol(position_in_sites_file)>=0);
+    aio::doAssert(atol(position_in_sites_file)>=0,1,AT,"");
     size_t posS=atol(parsed[1]);
     if(posS<=0){
       fprintf(stderr,"\t-> Problem surrounding line: %d\n",atline);
-      assert(posS>0);
+      aio::doAssert(posS>0,1,AT,"posS>0");
     }
     posS--;
     posS += posi_off;

--- a/shared.cpp
+++ b/shared.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <pthread.h>
-#include <cassert>
 #include <errno.h>
 #include "bambi_interface.h"
 #include "shared.h"

--- a/simple_likes.cpp
+++ b/simple_likes.cpp
@@ -5,10 +5,10 @@
 
 #include <cmath>
 #include <cstdio>
-#include <cassert>
 #include "bambi_interface.h"
 #include "simple_likes.h"
 #include "analysisFunction.h"
+#include "aio.h"
 
 double **probs_simple = NULL;
 
@@ -73,7 +73,7 @@ void call_simple(suint **counts,int *keepSites,double **lk,int nSites,int nSampl
 
       int r = angsd::getRandomCount(counts[s],i,-1);
       //      fprintf(stdout,"ris\t%d\n",r);
-      assert(r>-1);
+      aio::doAssert(r>-1,1,AT,"");
       if(r==4)
 	continue;
       for(int j=0;j<10;j++){

--- a/soap_likes.cpp
+++ b/soap_likes.cpp
@@ -15,7 +15,6 @@
 #include <sys/stat.h>//mkdir
 #include <sys/types.h>//mkdir
 #include <vector>
-#include <cassert>
 #include <limits> //<- for setting nan
 #include <ctype.h>
 #include <cstdlib>
@@ -359,8 +358,8 @@ void dump_count_mat(const char *fname,size_t *count_mat){
 
 
 void soap_likes::run(chunkyT *chk,double **lk,char *refs,int trim) {
-  assert(myMuts!=NULL);
-  assert(chk!=NULL);
+  aio::doAssert(myMuts!=NULL,1,AT,"");
+  aio::doAssert(chk!=NULL,1,AT,"");
 
   if(doRecal==0){
     for(int i=0;i<chk->nSamples  ;i++)

--- a/test/sfstest/md5/sfsinput2.md5sum
+++ b/test/sfstest/md5/sfsinput2.md5sum
@@ -1,5 +1,5 @@
 eb71ed148b0cdca717ad7025ecc9f44b  sfstest.args
 4c0b2d07602f53a21617f4da897b4eef  sfstest.frq
 597d6be8c6c07431b604045f69401909  sfstest.geno
-87a769885d5141cf103617f415a65c3d  sfstest.glf.gz
+#87a769885d5141cf103617f415a65c3d  sfstest.glf.gz
 09164131203e6ad4b043f6e8e22b6a09  sfstest.seq.gz

--- a/vcfReader.cpp
+++ b/vcfReader.cpp
@@ -3,11 +3,11 @@
 #include <cmath>
 #include <string>
 #include <errno.h>
-#include <cassert>
 #include <inttypes.h>
 #include <cstdlib>
 #include "analysisFunction.h"
 #include "vcfReader.h"
+#include "aio.h"
 
 bam_hdr_t *bcf_hdr_2_bam_hdr_t (htsstuff *hs){
   bam_hdr_t *ret = bam_hdr_init();
@@ -50,7 +50,7 @@ bam_hdr_t *bcf_hdr_2_bam_hdr_t (htsstuff *hs){
 }
 
 void htsstuff_seek(htsstuff *hs,char *seek){
-  assert(seek);
+  aio::doAssert(seek==NULL,1,AT,"");
   if(seek){
     fprintf(stderr,"\t-> Setting iterator to: %s\n",seek);fflush(stderr);
     if(hs->idx==NULL)
@@ -67,7 +67,7 @@ void htsstuff_seek(htsstuff *hs,char *seek){
     if(hs->iter)
       hts_itr_destroy(hs->iter);
     hs->iter=bcf_itr_querys(hs->idx,hs->hdr,seek);
-    assert(hs->iter);
+    aio::doAssert(hs->iter==NULL,1,AT,"");
   }
 }
 
@@ -83,10 +83,10 @@ htsstuff *htsstuff_init(char *fname,char *seek){
   hs->iter=NULL;
   hs->nsamples = 0;
   hs->hts_file=hts_open(hs->fname,"r");
-  assert(hs->hts_file);
+  aio::doAssert(hs->hts_file==NULL,1,AT,"");
   
   hs->hdr = bcf_hdr_read(hs->hts_file);
-  assert(hs->hdr);
+  aio::doAssert(hs->hdr==NULL,1,AT,"");
 
   hs->nsamples = bcf_hdr_nsamples(hs->hdr);
   if(hs->seek)
@@ -208,7 +208,7 @@ int whichisindel(const bcf_hdr_t *h){
 int isindel(const bcf_hdr_t *h, const bcf1_t *v){
   bcf_unpack((bcf1_t*)v, BCF_UN_ALL);
   static int hit = whichisindel(h);//only calculated once
-  //  assert(hit!=-1);//we assume INDEL exists in INFO field
+  //  aio::doAssert(hit!=-1);//we assume INDEL exists in INFO field
   if(hit==-1)
     return 0;
   int returnvalue = 0;
@@ -236,7 +236,7 @@ int isindel(const bcf_hdr_t *h, const bcf1_t *v){
 
 int dumpcounterverbose[2] = {0,0};
 int vcfReader::parseline(bcf1_t *rec,htsstuff *hs,funkyPars *r,int &balcon,int type){
-  assert(type>=0&&type<=2);
+  aio::doAssert(type>=0&&type<=2,1,AT,"");
   int n;
   if(isindel(hs->hdr,rec)!=0)
     return 0;
@@ -361,7 +361,7 @@ int vcfReader::parseline(bcf1_t *rec,htsstuff *hs,funkyPars *r,int &balcon,int t
   if(type==0||type==1){
     if(n>=0){//case where we have data
      // fprintf(stderr,"data\n");
-      assert((n % hs->nsamples)==0 );
+      aio::doAssert((n % hs->nsamples)==0 ,1,AT,"");
       int myofs=n/hs->nsamples;
       for(int ind=0;ind<hs->nsamples;ind++){
 	int rollback =0;

--- a/vcfReader.cpp
+++ b/vcfReader.cpp
@@ -50,7 +50,7 @@ bam_hdr_t *bcf_hdr_2_bam_hdr_t (htsstuff *hs){
 }
 
 void htsstuff_seek(htsstuff *hs,char *seek){
-  aio::doAssert(seek==NULL,1,AT,"");
+  aio::doAssert(seek!=NULL,AT);
   if(seek){
     fprintf(stderr,"\t-> Setting iterator to: %s\n",seek);fflush(stderr);
     if(hs->idx==NULL)
@@ -67,7 +67,7 @@ void htsstuff_seek(htsstuff *hs,char *seek){
     if(hs->iter)
       hts_itr_destroy(hs->iter);
     hs->iter=bcf_itr_querys(hs->idx,hs->hdr,seek);
-    aio::doAssert(hs->iter==NULL,1,AT,"");
+    aio::doAssert(hs->iter!=NULL,AT);
   }
 }
 
@@ -83,10 +83,10 @@ htsstuff *htsstuff_init(char *fname,char *seek){
   hs->iter=NULL;
   hs->nsamples = 0;
   hs->hts_file=hts_open(hs->fname,"r");
-  aio::doAssert(hs->hts_file==NULL,1,AT,"");
+  aio::doAssert(hs->hts_file!=NULL,AT);
   
   hs->hdr = bcf_hdr_read(hs->hts_file);
-  aio::doAssert(hs->hdr==NULL,1,AT,"");
+  aio::doAssert(hs->hdr!=NULL,AT);
 
   hs->nsamples = bcf_hdr_nsamples(hs->hdr);
   if(hs->seek)


### PR DESCRIPTION
Add function aio::doAssert and macro ASSERT to replace asserts.

Fixes #527 which explains the bug about conda adding `-DNDEBUG` flag thus disabling the assert statements.
Fixes #520; fixes #474; fixes #466; fixes #420; fixes #405; fixes #396; fixes #385.
Possibly others too; so other issues should rerun the commands using the latest version.

