### PR TITLE
[fix] Add -D__STDC_FORMAT_MACROS to FLAGS for C99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 
 #modied from htslib makefile
-FLAGS = -O3
+FLAGS = -O3 -D__STDC_FORMAT_MACROS
 CPPFLAGS := $(filter-out -DNDEBUG,$(CPPFLAGS))
 FLAGS2 = $(CPPFLAGS) $(FLAGS) $(LDFLAGS)
 


### PR DESCRIPTION
Add -D__STDC_FORMAT_MACROS flag to FLAGS in
Makefile. ISO C99 requires this predef for C++
clients before including inttypes.h. To avoid
doing this each time we instead add it to flags.

Fixes issues where compiler complains at vcfReader.cpp i.e. vcfReader.cpp:307:38: error: expected ')' before 'PRId64'

resolves #397
resolves #524
resolves #535