### PR TITLE
[fix] Add VCF spanning deletion check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ misc/splitgl
 misc/supersim
 misc/thetaStat
 version.h
+
+# Development-related files
+vgcore*
+commit_message.txt


### PR DESCRIPTION
Issue: VCF v4.2 introduced the use of asterisk notation (`*`) in ALTs to represent spanning deletions. If there are alternative alleles at a site, the ‘`*`’ allele is reserved to indicate that an allele allele is missing due to an upstream deletion. This was not considered in angsd VCF reading and led to segfaults. Fix: Add hasSpanningDeletion function to check if there is any spanning deletion and skip the sites with spanning deletion. Fixes #557

Add development-related files to gitignore:
-vgcore files from valgrind
-commit_message.txt commit message template