### PR TITLE
[build] Remove install -D to support osx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ bindir      = $(exec_prefix)/bin
 
 INSTALL = install
 INSTALL_DIR = $(INSTALL) -dm0755
-INSTALL_PROGRAM = $(INSTALL) -Dm0755
+INSTALL_PROGRAM = $(INSTALL) -m0755
 
 #$(info CFLAGS=$(CFLAGS))
 #$(info CXXFLAGS=$(CXXFLAGS))


### PR DESCRIPTION
Remove `-D` flag from install.
Regular install in macOS does not have the flag `-D`. This causes the bioconda package to fail building the conda package for osx. `-d` in previous line should already create the dirs if needed, so `-D` is not necessary anyway.


Reference:
[Build error from bioconda tests (line 1424)](https://dev.azure.com/bioconda/bioconda-recipes/_build/results?buildId=32962&view=logs&j=1b052f1d-4456-52f0-9d43-71c4c5bd734d&t=edc48dcd-1fc2-5e3b-7036-7be9cea00123&l=1424)