### PR TITLE
[fix] Add missing parenthesis to assert macro

### DIFF
--- a/aio.h
+++ b/aio.h
@@ -17,7 +17,7 @@
  * Macro:[ASSERT]
  * shortcut to evaluate an expression, works the same way as the C-macro assert
  */
-#define ASSERT(expr) if (!(expr)) {fprintf(stderr,"\n\n*******\n[ERROR](%s:%d) %s\n*******\n",__FILE__,__LINE__,#expr);exit(1);}
+#define ASSERT(expr) if (!((expr))) {fprintf(stderr,"\n\n*******\n[ERROR](%s:%d) %s\n*******\n",__FILE__,__LINE__,#expr);exit(1);}
 
 
 //angsd io


### PR DESCRIPTION
Add extra parenthesis to assert macro to avoid
cases where ASSERT(x>y) expands to if(!x>y)
instead of if(!(x>y))