### PR TITLE
Makefile: specify version.h as a dependency of all object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,9 @@ misc: analysisFunction.o bfgs.o prep_sites.o
 	$(CXX) -c  $(CXXFLAGS) $*.cpp
 	$(CXX) -MM $(CXXFLAGS) $*.cpp >$*.d
 
+$(OBJ): version.h
 
-angsd: version.h $(OBJ)
+angsd: $(OBJ)
 	$(CXX) $(FLAGS) -o angsd *.o $(LIBS)
 
 


### PR DESCRIPTION
Otherwise parallel builds fail occasionally as:

    $ make --shuffle -j
    ...
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   argStruct.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   ancestral_likes.cpp
    gcc -c   -O3 -D__STDC_FORMAT_MACROS   fet.c
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   abcGL.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   pop1_read.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   angsd.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   abcHWE_F.cpp
    gcc -c   -O3 -D__STDC_FORMAT_MACROS   kprobaln.c
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   mpileup.cpp
    argStruct.cpp:3:10: fatal error: version.h: No such file or directory
        3 | #include "version.h"
          |          ^~~~~~~~~~~
    compilation terminated.
    angsd.cpp:11:10: fatal error: version.h: No such file or directory
       11 | #include "version.h"
          |          ^~~~~~~~~~~

Before the change it was enough to try to build `angsd` with 1-2 `make --shuffle` runs to get the failure. After the change the build survives 20 rebuilds.